### PR TITLE
Added Authentication (and all the pages/API routes/context/components/etc. required to facilitate it)

### DIFF
--- a/components.json
+++ b/components.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "default",
+  "rsc": false,
+  "tsx": false,
+  "tailwind": {
+    "config": "tailwind.config.js",
+    "css": "src/styles/globals.css",
+    "baseColor": "slate",
+    "cssVariables": true
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/utils/utils"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,18 @@
             "name": "coleaseum-webapp",
             "version": "0.1.0",
             "dependencies": {
+                "@emotion/react": "^11.11.1",
+                "@emotion/styled": "^11.11.0",
+                "@mui/material": "^5.14.18",
                 "@radix-ui/react-popover": "^1.0.7",
                 "@radix-ui/react-select": "^2.0.0",
                 "@radix-ui/react-slot": "^1.0.2",
+                "bcryptjs": "^2.4.3",
                 "class-variance-authority": "^0.7.0",
                 "clsx": "^2.0.0",
                 "date-fns": "^2.30.0",
+                "jsonwebtoken": "^9.0.2",
+                "jwt-decode": "^4.0.0",
                 "lucide-react": "^0.292.0",
                 "mongoose": "^8.0.0",
                 "next": "14.0.1",
@@ -43,6 +49,58 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/@babel/code-frame": {
+            "version": "7.22.13",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
+            "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+            "dependencies": {
+                "@babel/highlight": "^7.22.13",
+                "chalk": "^2.4.2"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-imports": {
+            "version": "7.22.15",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
+            "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
+            "dependencies": {
+                "@babel/types": "^7.22.15"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-string-parser": {
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
+            "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-validator-identifier": {
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+            "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/highlight": {
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
+            "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.22.20",
+                "chalk": "^2.4.2",
+                "js-tokens": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@babel/runtime": {
             "version": "7.23.2",
             "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
@@ -53,6 +111,152 @@
             "engines": {
                 "node": ">=6.9.0"
             }
+        },
+        "node_modules/@babel/types": {
+            "version": "7.23.3",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.3.tgz",
+            "integrity": "sha512-OZnvoH2l8PK5eUvEcUyCt/sXgr/h+UWpVuBbOljwcrAgUl6lpchoQ++PHGyQy1AtYnVA6CEq3y5xeEI10brpXw==",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.22.5",
+                "@babel/helper-validator-identifier": "^7.22.20",
+                "to-fast-properties": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@emotion/babel-plugin": {
+            "version": "11.11.0",
+            "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz",
+            "integrity": "sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==",
+            "dependencies": {
+                "@babel/helper-module-imports": "^7.16.7",
+                "@babel/runtime": "^7.18.3",
+                "@emotion/hash": "^0.9.1",
+                "@emotion/memoize": "^0.8.1",
+                "@emotion/serialize": "^1.1.2",
+                "babel-plugin-macros": "^3.1.0",
+                "convert-source-map": "^1.5.0",
+                "escape-string-regexp": "^4.0.0",
+                "find-root": "^1.1.0",
+                "source-map": "^0.5.7",
+                "stylis": "4.2.0"
+            }
+        },
+        "node_modules/@emotion/cache": {
+            "version": "11.11.0",
+            "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.11.0.tgz",
+            "integrity": "sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==",
+            "dependencies": {
+                "@emotion/memoize": "^0.8.1",
+                "@emotion/sheet": "^1.2.2",
+                "@emotion/utils": "^1.2.1",
+                "@emotion/weak-memoize": "^0.3.1",
+                "stylis": "4.2.0"
+            }
+        },
+        "node_modules/@emotion/hash": {
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
+            "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
+        },
+        "node_modules/@emotion/is-prop-valid": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
+            "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
+            "dependencies": {
+                "@emotion/memoize": "^0.8.1"
+            }
+        },
+        "node_modules/@emotion/memoize": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+            "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
+        },
+        "node_modules/@emotion/react": {
+            "version": "11.11.1",
+            "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.1.tgz",
+            "integrity": "sha512-5mlW1DquU5HaxjLkfkGN1GA/fvVGdyHURRiX/0FHl2cfIfRxSOfmxEH5YS43edp0OldZrZ+dkBKbngxcNCdZvA==",
+            "dependencies": {
+                "@babel/runtime": "^7.18.3",
+                "@emotion/babel-plugin": "^11.11.0",
+                "@emotion/cache": "^11.11.0",
+                "@emotion/serialize": "^1.1.2",
+                "@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
+                "@emotion/utils": "^1.2.1",
+                "@emotion/weak-memoize": "^0.3.1",
+                "hoist-non-react-statics": "^3.3.1"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@emotion/serialize": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.2.tgz",
+            "integrity": "sha512-zR6a/fkFP4EAcCMQtLOhIgpprZOwNmCldtpaISpvz348+DP4Mz8ZoKaGGCQpbzepNIUWbq4w6hNZkwDyKoS+HA==",
+            "dependencies": {
+                "@emotion/hash": "^0.9.1",
+                "@emotion/memoize": "^0.8.1",
+                "@emotion/unitless": "^0.8.1",
+                "@emotion/utils": "^1.2.1",
+                "csstype": "^3.0.2"
+            }
+        },
+        "node_modules/@emotion/sheet": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.2.tgz",
+            "integrity": "sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA=="
+        },
+        "node_modules/@emotion/styled": {
+            "version": "11.11.0",
+            "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.11.0.tgz",
+            "integrity": "sha512-hM5Nnvu9P3midq5aaXj4I+lnSfNi7Pmd4EWk1fOZ3pxookaQTNew6bp4JaCBYM4HVFZF9g7UjJmsUmC2JlxOng==",
+            "dependencies": {
+                "@babel/runtime": "^7.18.3",
+                "@emotion/babel-plugin": "^11.11.0",
+                "@emotion/is-prop-valid": "^1.2.1",
+                "@emotion/serialize": "^1.1.2",
+                "@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
+                "@emotion/utils": "^1.2.1"
+            },
+            "peerDependencies": {
+                "@emotion/react": "^11.0.0-rc.0",
+                "react": ">=16.8.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@emotion/unitless": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
+            "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
+        },
+        "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz",
+            "integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==",
+            "peerDependencies": {
+                "react": ">=16.8.0"
+            }
+        },
+        "node_modules/@emotion/utils": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.1.tgz",
+            "integrity": "sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg=="
+        },
+        "node_modules/@emotion/weak-memoize": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
+            "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
         },
         "node_modules/@floating-ui/core": {
             "version": "1.5.0",
@@ -137,6 +341,226 @@
             "integrity": "sha512-t7c5K033joZZMspnHg/gWPE4kandgc2OxE74aYOtGKfgB9VPuVJPix0H6fhmm2erj5PBJ21mqcx34lpIGtUCsQ==",
             "dependencies": {
                 "sparse-bitfield": "^3.0.3"
+            }
+        },
+        "node_modules/@mui/base": {
+            "version": "5.0.0-beta.24",
+            "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.24.tgz",
+            "integrity": "sha512-bKt2pUADHGQtqWDZ8nvL2Lvg2GNJyd/ZUgZAJoYzRgmnxBL9j36MSlS3+exEdYkikcnvVafcBtD904RypFKb0w==",
+            "dependencies": {
+                "@babel/runtime": "^7.23.2",
+                "@floating-ui/react-dom": "^2.0.4",
+                "@mui/types": "^7.2.9",
+                "@mui/utils": "^5.14.18",
+                "@popperjs/core": "^2.11.8",
+                "clsx": "^2.0.0",
+                "prop-types": "^15.8.1"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui"
+            },
+            "peerDependencies": {
+                "@types/react": "^17.0.0 || ^18.0.0",
+                "react": "^17.0.0 || ^18.0.0",
+                "react-dom": "^17.0.0 || ^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@mui/core-downloads-tracker": {
+            "version": "5.14.18",
+            "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.14.18.tgz",
+            "integrity": "sha512-yFpF35fEVDV81nVktu0BE9qn2dD/chs7PsQhlyaV3EnTeZi9RZBuvoEfRym1/jmhJ2tcfeWXiRuHG942mQXJJQ==",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui"
+            }
+        },
+        "node_modules/@mui/material": {
+            "version": "5.14.18",
+            "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.14.18.tgz",
+            "integrity": "sha512-y3UiR/JqrkF5xZR0sIKj6y7xwuEiweh9peiN3Zfjy1gXWXhz5wjlaLdoxFfKIEBUFfeQALxr/Y8avlHH+B9lpQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.23.2",
+                "@mui/base": "5.0.0-beta.24",
+                "@mui/core-downloads-tracker": "^5.14.18",
+                "@mui/system": "^5.14.18",
+                "@mui/types": "^7.2.9",
+                "@mui/utils": "^5.14.18",
+                "@types/react-transition-group": "^4.4.8",
+                "clsx": "^2.0.0",
+                "csstype": "^3.1.2",
+                "prop-types": "^15.8.1",
+                "react-is": "^18.2.0",
+                "react-transition-group": "^4.4.5"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui"
+            },
+            "peerDependencies": {
+                "@emotion/react": "^11.5.0",
+                "@emotion/styled": "^11.3.0",
+                "@types/react": "^17.0.0 || ^18.0.0",
+                "react": "^17.0.0 || ^18.0.0",
+                "react-dom": "^17.0.0 || ^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@emotion/react": {
+                    "optional": true
+                },
+                "@emotion/styled": {
+                    "optional": true
+                },
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@mui/private-theming": {
+            "version": "5.14.18",
+            "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.14.18.tgz",
+            "integrity": "sha512-WSgjqRlzfHU+2Rou3HlR2Gqfr4rZRsvFgataYO3qQ0/m6gShJN+lhVEvwEiJ9QYyVzMDvNpXZAcqp8Y2Vl+PAw==",
+            "dependencies": {
+                "@babel/runtime": "^7.23.2",
+                "@mui/utils": "^5.14.18",
+                "prop-types": "^15.8.1"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui"
+            },
+            "peerDependencies": {
+                "@types/react": "^17.0.0 || ^18.0.0",
+                "react": "^17.0.0 || ^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@mui/styled-engine": {
+            "version": "5.14.18",
+            "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.14.18.tgz",
+            "integrity": "sha512-pW8bpmF9uCB5FV2IPk6mfbQCjPI5vGI09NOLhtGXPeph/4xIfC3JdIX0TILU0WcTs3aFQqo6s2+1SFgIB9rCXA==",
+            "dependencies": {
+                "@babel/runtime": "^7.23.2",
+                "@emotion/cache": "^11.11.0",
+                "csstype": "^3.1.2",
+                "prop-types": "^15.8.1"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui"
+            },
+            "peerDependencies": {
+                "@emotion/react": "^11.4.1",
+                "@emotion/styled": "^11.3.0",
+                "react": "^17.0.0 || ^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@emotion/react": {
+                    "optional": true
+                },
+                "@emotion/styled": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@mui/system": {
+            "version": "5.14.18",
+            "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.14.18.tgz",
+            "integrity": "sha512-hSQQdb3KF72X4EN2hMEiv8EYJZSflfdd1TRaGPoR7CIAG347OxCslpBUwWngYobaxgKvq6xTrlIl+diaactVww==",
+            "dependencies": {
+                "@babel/runtime": "^7.23.2",
+                "@mui/private-theming": "^5.14.18",
+                "@mui/styled-engine": "^5.14.18",
+                "@mui/types": "^7.2.9",
+                "@mui/utils": "^5.14.18",
+                "clsx": "^2.0.0",
+                "csstype": "^3.1.2",
+                "prop-types": "^15.8.1"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui"
+            },
+            "peerDependencies": {
+                "@emotion/react": "^11.5.0",
+                "@emotion/styled": "^11.3.0",
+                "@types/react": "^17.0.0 || ^18.0.0",
+                "react": "^17.0.0 || ^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@emotion/react": {
+                    "optional": true
+                },
+                "@emotion/styled": {
+                    "optional": true
+                },
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@mui/types": {
+            "version": "7.2.9",
+            "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.9.tgz",
+            "integrity": "sha512-k1lN/PolaRZfNsRdAqXtcR71sTnv3z/VCCGPxU8HfdftDkzi335MdJ6scZxvofMAd/K/9EbzCZTFBmlNpQVdCg==",
+            "peerDependencies": {
+                "@types/react": "^17.0.0 || ^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@mui/utils": {
+            "version": "5.14.18",
+            "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.14.18.tgz",
+            "integrity": "sha512-HZDRsJtEZ7WMSnrHV9uwScGze4wM/Y+u6pDVo+grUjt5yXzn+wI8QX/JwTHh9YSw/WpnUL80mJJjgCnWj2VrzQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.23.2",
+                "@types/prop-types": "^15.7.10",
+                "prop-types": "^15.8.1",
+                "react-is": "^18.2.0"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui"
+            },
+            "peerDependencies": {
+                "@types/react": "^17.0.0 || ^18.0.0",
+                "react": "^17.0.0 || ^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@next/env": {
@@ -309,6 +733,15 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/@popperjs/core": {
+            "version": "2.11.8",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+            "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/popperjs"
             }
         },
         "node_modules/@radix-ui/number": {
@@ -884,6 +1317,39 @@
                 "undici-types": "~5.26.4"
             }
         },
+        "node_modules/@types/parse-json": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+            "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="
+        },
+        "node_modules/@types/prop-types": {
+            "version": "15.7.10",
+            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.10.tgz",
+            "integrity": "sha512-mxSnDQxPqsZxmeShFH+uwQ4kO4gcJcGahjjMFeLbKE95IAZiiZyiEepGZjtXJ7hN/yfu0bu9xN2ajcU0JcxX6A=="
+        },
+        "node_modules/@types/react": {
+            "version": "18.2.37",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.37.tgz",
+            "integrity": "sha512-RGAYMi2bhRgEXT3f4B92WTohopH6bIXw05FuGlmJEnv/omEn190+QYEIYxIAuIBdKgboYYdVved2p1AxZVQnaw==",
+            "dependencies": {
+                "@types/prop-types": "*",
+                "@types/scheduler": "*",
+                "csstype": "^3.0.2"
+            }
+        },
+        "node_modules/@types/react-transition-group": {
+            "version": "4.4.9",
+            "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.9.tgz",
+            "integrity": "sha512-ZVNmWumUIh5NhH8aMD9CR2hdW0fNuYInlocZHaZ+dgk/1K49j1w/HoAuK1ki+pgscQrOFRTlXeoURtuzEkV3dg==",
+            "dependencies": {
+                "@types/react": "*"
+            }
+        },
+        "node_modules/@types/scheduler": {
+            "version": "0.16.6",
+            "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.6.tgz",
+            "integrity": "sha512-Vlktnchmkylvc9SnwwwozTv04L/e1NykF5vgoQ0XTmI8DD+wxfjQuHuvHS3p0r2jz2x2ghPs2h1FVeDirIteWA=="
+        },
         "node_modules/@types/webidl-conversions": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
@@ -896,6 +1362,17 @@
             "dependencies": {
                 "@types/node": "*",
                 "@types/webidl-conversions": "*"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dependencies": {
+                "color-convert": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/any-promise": {
@@ -968,10 +1445,29 @@
                 "postcss": "^8.1.0"
             }
         },
+        "node_modules/babel-plugin-macros": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+            "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+            "dependencies": {
+                "@babel/runtime": "^7.12.5",
+                "cosmiconfig": "^7.0.0",
+                "resolve": "^1.19.0"
+            },
+            "engines": {
+                "node": ">=10",
+                "npm": ">=6"
+            }
+        },
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+        },
+        "node_modules/bcryptjs": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+            "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ=="
         },
         "node_modules/binary-extensions": {
             "version": "2.2.0",
@@ -1041,6 +1537,11 @@
                 "node": ">=16.20.1"
             }
         },
+        "node_modules/buffer-equal-constant-time": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+            "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+        },
         "node_modules/busboy": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -1050,6 +1551,14 @@
             },
             "engines": {
                 "node": ">=10.16.0"
+            }
+        },
+        "node_modules/callsites": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/camelcase-css": {
@@ -1078,6 +1587,27 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ]
+        },
+        "node_modules/chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/chalk/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "engines": {
+                "node": ">=0.8.0"
+            }
         },
         "node_modules/chokidar": {
             "version": "3.5.3",
@@ -1145,6 +1675,19 @@
                 "node": ">=6"
             }
         },
+        "node_modules/color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dependencies": {
+                "color-name": "1.1.3"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+        },
         "node_modules/commander": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -1158,6 +1701,34 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
         },
+        "node_modules/convert-source-map": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+            "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+        },
+        "node_modules/cosmiconfig": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+            "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+            "dependencies": {
+                "@types/parse-json": "^4.0.0",
+                "import-fresh": "^3.2.1",
+                "parse-json": "^5.0.0",
+                "path-type": "^4.0.0",
+                "yaml": "^1.10.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/cosmiconfig/node_modules/yaml": {
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+            "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/cssesc": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -1168,6 +1739,11 @@
             "engines": {
                 "node": ">=4"
             }
+        },
+        "node_modules/csstype": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+            "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
         },
         "node_modules/date-fns": {
             "version": "2.30.0",
@@ -1220,6 +1796,23 @@
             "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
             "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
         },
+        "node_modules/dom-helpers": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+            "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "csstype": "^3.0.2"
+            }
+        },
+        "node_modules/ecdsa-sig-formatter": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+            "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+            "dependencies": {
+                "safe-buffer": "^5.0.1"
+            }
+        },
         "node_modules/electron-to-chromium": {
             "version": "1.4.578",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.578.tgz",
@@ -1231,6 +1824,14 @@
             "resolved": "https://registry.npmjs.org/enquire.js/-/enquire.js-2.1.6.tgz",
             "integrity": "sha512-/KujNpO+PT63F7Hlpu4h3pE3TokKRHN26JYmQpPyjkRD/N57R7bPDNojMXdi7uveAKjYB7yQnartCxZnFWr0Xw=="
         },
+        "node_modules/error-ex": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+            "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+            "dependencies": {
+                "is-arrayish": "^0.2.1"
+            }
+        },
         "node_modules/escalade": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -1238,6 +1839,17 @@
             "dev": true,
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/fast-glob": {
@@ -1284,6 +1896,11 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/find-root": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+            "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
         },
         "node_modules/fraction.js": {
             "version": "4.3.7",
@@ -1372,6 +1989,14 @@
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
         },
+        "node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/hasown": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
@@ -1381,6 +2006,34 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/hoist-non-react-statics": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+            "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+            "dependencies": {
+                "react-is": "^16.7.0"
+            }
+        },
+        "node_modules/hoist-non-react-statics/node_modules/react-is": {
+            "version": "16.13.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
+        "node_modules/import-fresh": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+            "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+            "dependencies": {
+                "parent-module": "^1.0.0",
+                "resolve-from": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/inflight": {
@@ -1404,6 +2057,11 @@
             "dependencies": {
                 "loose-envify": "^1.0.0"
             }
+        },
+        "node_modules/is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
         },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
@@ -1473,12 +2131,65 @@
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
+        "node_modules/json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+        },
         "node_modules/json2mq": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
             "integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
             "dependencies": {
                 "string-convert": "^0.2.0"
+            }
+        },
+        "node_modules/jsonwebtoken": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+            "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+            "dependencies": {
+                "jws": "^3.2.2",
+                "lodash.includes": "^4.3.0",
+                "lodash.isboolean": "^3.0.3",
+                "lodash.isinteger": "^4.0.4",
+                "lodash.isnumber": "^3.0.3",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.isstring": "^4.0.1",
+                "lodash.once": "^4.0.0",
+                "ms": "^2.1.1",
+                "semver": "^7.5.4"
+            },
+            "engines": {
+                "node": ">=12",
+                "npm": ">=6"
+            }
+        },
+        "node_modules/jwa": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+            "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+            "dependencies": {
+                "buffer-equal-constant-time": "1.0.1",
+                "ecdsa-sig-formatter": "1.0.11",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "node_modules/jws": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+            "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+            "dependencies": {
+                "jwa": "^1.4.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "node_modules/jwt-decode": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+            "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/kareem": {
@@ -1507,6 +2218,41 @@
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
             "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
         },
+        "node_modules/lodash.includes": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+            "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+        },
+        "node_modules/lodash.isboolean": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+            "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+        },
+        "node_modules/lodash.isinteger": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+            "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+        },
+        "node_modules/lodash.isnumber": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+            "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+        },
+        "node_modules/lodash.isplainobject": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+        },
+        "node_modules/lodash.isstring": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+            "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+        },
+        "node_modules/lodash.once": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+            "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+        },
         "node_modules/loose-envify": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -1516,6 +2262,17 @@
             },
             "bin": {
                 "loose-envify": "cli.js"
+            }
+        },
+        "node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/lucide-react": {
@@ -1780,6 +2537,34 @@
                 "wrappy": "1"
             }
         },
+        "node_modules/parent-module": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+            "dependencies": {
+                "callsites": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/parse-json": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+            "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+            "dependencies": {
+                "@babel/code-frame": "^7.0.0",
+                "error-ex": "^1.3.1",
+                "json-parse-even-better-errors": "^2.3.0",
+                "lines-and-columns": "^1.1.6"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -1792,6 +2577,14 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+        },
+        "node_modules/path-type": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/picocolors": {
             "version": "1.0.0",
@@ -1949,6 +2742,21 @@
             "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
             "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
         },
+        "node_modules/prop-types": {
+            "version": "15.8.1",
+            "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+            "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+            "dependencies": {
+                "loose-envify": "^1.4.0",
+                "object-assign": "^4.1.1",
+                "react-is": "^16.13.1"
+            }
+        },
+        "node_modules/prop-types/node_modules/react-is": {
+            "version": "16.13.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
         "node_modules/punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2019,6 +2827,11 @@
             "peerDependencies": {
                 "react": "*"
             }
+        },
+        "node_modules/react-is": {
+            "version": "18.2.0",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+            "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
         },
         "node_modules/react-remove-scroll": {
             "version": "2.5.5",
@@ -2103,6 +2916,21 @@
                 }
             }
         },
+        "node_modules/react-transition-group": {
+            "version": "4.4.5",
+            "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+            "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+            "dependencies": {
+                "@babel/runtime": "^7.5.5",
+                "dom-helpers": "^5.0.1",
+                "loose-envify": "^1.4.0",
+                "prop-types": "^15.6.2"
+            },
+            "peerDependencies": {
+                "react": ">=16.6.0",
+                "react-dom": ">=16.6.0"
+            }
+        },
         "node_modules/read-cache": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -2148,6 +2976,14 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/resolve-from": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/reusify": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -2179,12 +3015,45 @@
                 "queue-microtask": "^1.2.2"
             }
         },
+        "node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
+        },
         "node_modules/scheduler": {
             "version": "0.23.0",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
             "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
             "dependencies": {
                 "loose-envify": "^1.1.0"
+            }
+        },
+        "node_modules/semver": {
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/sift": {
@@ -2198,6 +3067,14 @@
             "integrity": "sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA==",
             "peerDependencies": {
                 "jquery": ">=1.8.0"
+            }
+        },
+        "node_modules/source-map": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/source-map-js": {
@@ -2251,6 +3128,11 @@
                 }
             }
         },
+        "node_modules/stylis": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+            "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
+        },
         "node_modules/sucrase": {
             "version": "3.34.0",
             "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.34.0.tgz",
@@ -2270,6 +3152,17 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/supports-preserve-symlinks-flag": {
@@ -2356,6 +3249,14 @@
             },
             "engines": {
                 "node": ">=0.8"
+            }
+        },
+        "node_modules/to-fast-properties": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+            "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/to-regex-range": {
@@ -2507,6 +3408,11 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+        },
+        "node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "node_modules/yaml": {
             "version": "2.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,30 @@
 {
-    "name": "sublet-webapp-next",
+    "name": "coleaseum-webapp",
     "version": "0.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "sublet-webapp-next",
+            "name": "coleaseum-webapp",
             "version": "0.1.0",
             "dependencies": {
+                "@radix-ui/react-popover": "^1.0.7",
+                "@radix-ui/react-select": "^2.0.0",
+                "@radix-ui/react-slot": "^1.0.2",
+                "class-variance-authority": "^0.7.0",
                 "clsx": "^2.0.0",
+                "date-fns": "^2.30.0",
+                "lucide-react": "^0.292.0",
                 "mongoose": "^8.0.0",
                 "next": "14.0.1",
                 "react": "^18",
+                "react-day-picker": "^8.9.1",
                 "react-dom": "^18",
                 "react-icons": "^4.11.0",
                 "react-slick": "^0.29.0",
                 "slick-carousel": "^1.8.1",
-                "tailwind-merge": "^2.0.0"
+                "tailwind-merge": "^2.0.0",
+                "tailwindcss-animate": "^1.0.7"
             },
             "devDependencies": {
                 "autoprefixer": "^10.0.1",
@@ -28,7 +36,6 @@
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
             "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-            "dev": true,
             "engines": {
                 "node": ">=10"
             },
@@ -47,11 +54,44 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@floating-ui/core": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.0.tgz",
+            "integrity": "sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==",
+            "dependencies": {
+                "@floating-ui/utils": "^0.1.3"
+            }
+        },
+        "node_modules/@floating-ui/dom": {
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.3.tgz",
+            "integrity": "sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==",
+            "dependencies": {
+                "@floating-ui/core": "^1.4.2",
+                "@floating-ui/utils": "^0.1.3"
+            }
+        },
+        "node_modules/@floating-ui/react-dom": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.4.tgz",
+            "integrity": "sha512-CF8k2rgKeh/49UrnIBs4BdxPUV6vize/Db1d/YbCLyp9GiVZ0BEwf5AiDSxJRCr6yOkGqTFHtmrULxkEfYZ7dQ==",
+            "dependencies": {
+                "@floating-ui/dom": "^1.5.1"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0",
+                "react-dom": ">=16.8.0"
+            }
+        },
+        "node_modules/@floating-ui/utils": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
+            "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A=="
+        },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.3",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
             "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
-            "dev": true,
             "dependencies": {
                 "@jridgewell/set-array": "^1.0.1",
                 "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -65,7 +105,6 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
             "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
-            "dev": true,
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -74,7 +113,6 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
             "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-            "dev": true,
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -82,14 +120,12 @@
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.4.15",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-            "dev": true
+            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.20",
             "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
             "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
-            "dev": true,
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -247,7 +283,6 @@
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
             "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-            "dev": true,
             "dependencies": {
                 "@nodelib/fs.stat": "2.0.5",
                 "run-parallel": "^1.1.9"
@@ -260,7 +295,6 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
             "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-            "dev": true,
             "engines": {
                 "node": ">= 8"
             }
@@ -269,13 +303,569 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
             "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-            "dev": true,
             "dependencies": {
                 "@nodelib/fs.scandir": "2.1.5",
                 "fastq": "^1.6.0"
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/@radix-ui/number": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.0.1.tgz",
+            "integrity": "sha512-T5gIdVO2mmPW3NNhjNgEP3cqMXjXL9UbO0BzWcXfvdBs+BohbQxvd/K5hSVKmn9/lbTdsQVKbUcP5WLCwvUbBg==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10"
+            }
+        },
+        "node_modules/@radix-ui/primitive": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.1.tgz",
+            "integrity": "sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10"
+            }
+        },
+        "node_modules/@radix-ui/react-arrow": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.0.3.tgz",
+            "integrity": "sha512-wSP+pHsB/jQRaL6voubsQ/ZlrGBHHrOjmBnr19hxYgtS0WvAFwZhK2WP/YY5yF9uKECCEEDGxuLxq1NBK51wFA==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-primitive": "1.0.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0",
+                "react-dom": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-collection": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.3.tgz",
+            "integrity": "sha512-3SzW+0PW7yBBoQlT8wNcGtaxaD0XSu0uLUFgrtHY08Acx05TaHaOmVLR73c0j/cqpDy53KBMO7s0dx2wmOIDIA==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-compose-refs": "1.0.1",
+                "@radix-ui/react-context": "1.0.1",
+                "@radix-ui/react-primitive": "1.0.3",
+                "@radix-ui/react-slot": "1.0.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0",
+                "react-dom": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-compose-refs": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz",
+            "integrity": "sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-context": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.1.tgz",
+            "integrity": "sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-direction": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.1.tgz",
+            "integrity": "sha512-RXcvnXgyvYvBEOhCBuddKecVkoMiI10Jcm5cTI7abJRAHYfFxeu+FBQs/DvdxSYucxR5mna0dNsL6QFlds5TMA==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-dismissable-layer": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.5.tgz",
+            "integrity": "sha512-aJeDjQhywg9LBu2t/At58hCvr7pEm0o2Ke1x33B+MhjNmmZ17sy4KImo0KPLgsnc/zN7GPdce8Cnn0SWvwZO7g==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/primitive": "1.0.1",
+                "@radix-ui/react-compose-refs": "1.0.1",
+                "@radix-ui/react-primitive": "1.0.3",
+                "@radix-ui/react-use-callback-ref": "1.0.1",
+                "@radix-ui/react-use-escape-keydown": "1.0.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0",
+                "react-dom": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-focus-guards": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.1.tgz",
+            "integrity": "sha512-Rect2dWbQ8waGzhMavsIbmSVCgYxkXLxxR3ZvCX79JOglzdEy4JXMb98lq4hPxUbLr77nP0UOGf4rcMU+s1pUA==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-focus-scope": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.0.4.tgz",
+            "integrity": "sha512-sL04Mgvf+FmyvZeYfNu1EPAaaxD+aw7cYeIB9L9Fvq8+urhltTRaEo5ysKOpHuKPclsZcSUMKlN05x4u+CINpA==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-compose-refs": "1.0.1",
+                "@radix-ui/react-primitive": "1.0.3",
+                "@radix-ui/react-use-callback-ref": "1.0.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0",
+                "react-dom": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-id": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.1.tgz",
+            "integrity": "sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-use-layout-effect": "1.0.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-popover": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.0.7.tgz",
+            "integrity": "sha512-shtvVnlsxT6faMnK/a7n0wptwBD23xc1Z5mdrtKLwVEfsEMXodS0r5s0/g5P0hX//EKYZS2sxUjqfzlg52ZSnQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/primitive": "1.0.1",
+                "@radix-ui/react-compose-refs": "1.0.1",
+                "@radix-ui/react-context": "1.0.1",
+                "@radix-ui/react-dismissable-layer": "1.0.5",
+                "@radix-ui/react-focus-guards": "1.0.1",
+                "@radix-ui/react-focus-scope": "1.0.4",
+                "@radix-ui/react-id": "1.0.1",
+                "@radix-ui/react-popper": "1.1.3",
+                "@radix-ui/react-portal": "1.0.4",
+                "@radix-ui/react-presence": "1.0.1",
+                "@radix-ui/react-primitive": "1.0.3",
+                "@radix-ui/react-slot": "1.0.2",
+                "@radix-ui/react-use-controllable-state": "1.0.1",
+                "aria-hidden": "^1.1.1",
+                "react-remove-scroll": "2.5.5"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0",
+                "react-dom": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-popper": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.1.3.tgz",
+            "integrity": "sha512-cKpopj/5RHZWjrbF2846jBNacjQVwkP068DfmgrNJXpvVWrOvlAmE9xSiy5OqeE+Gi8D9fP+oDhUnPqNMY8/5w==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@floating-ui/react-dom": "^2.0.0",
+                "@radix-ui/react-arrow": "1.0.3",
+                "@radix-ui/react-compose-refs": "1.0.1",
+                "@radix-ui/react-context": "1.0.1",
+                "@radix-ui/react-primitive": "1.0.3",
+                "@radix-ui/react-use-callback-ref": "1.0.1",
+                "@radix-ui/react-use-layout-effect": "1.0.1",
+                "@radix-ui/react-use-rect": "1.0.1",
+                "@radix-ui/react-use-size": "1.0.1",
+                "@radix-ui/rect": "1.0.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0",
+                "react-dom": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-portal": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.0.4.tgz",
+            "integrity": "sha512-Qki+C/EuGUVCQTOTD5vzJzJuMUlewbzuKyUy+/iHM2uwGiru9gZeBJtHAPKAEkB5KWGi9mP/CHKcY0wt1aW45Q==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-primitive": "1.0.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0",
+                "react-dom": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-presence": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.1.tgz",
+            "integrity": "sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-compose-refs": "1.0.1",
+                "@radix-ui/react-use-layout-effect": "1.0.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0",
+                "react-dom": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-primitive": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz",
+            "integrity": "sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-slot": "1.0.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0",
+                "react-dom": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-select": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.0.0.tgz",
+            "integrity": "sha512-RH5b7af4oHtkcHS7pG6Sgv5rk5Wxa7XI8W5gvB1N/yiuDGZxko1ynvOiVhFM7Cis2A8zxF9bTOUVbRDzPepe6w==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/number": "1.0.1",
+                "@radix-ui/primitive": "1.0.1",
+                "@radix-ui/react-collection": "1.0.3",
+                "@radix-ui/react-compose-refs": "1.0.1",
+                "@radix-ui/react-context": "1.0.1",
+                "@radix-ui/react-direction": "1.0.1",
+                "@radix-ui/react-dismissable-layer": "1.0.5",
+                "@radix-ui/react-focus-guards": "1.0.1",
+                "@radix-ui/react-focus-scope": "1.0.4",
+                "@radix-ui/react-id": "1.0.1",
+                "@radix-ui/react-popper": "1.1.3",
+                "@radix-ui/react-portal": "1.0.4",
+                "@radix-ui/react-primitive": "1.0.3",
+                "@radix-ui/react-slot": "1.0.2",
+                "@radix-ui/react-use-callback-ref": "1.0.1",
+                "@radix-ui/react-use-controllable-state": "1.0.1",
+                "@radix-ui/react-use-layout-effect": "1.0.1",
+                "@radix-ui/react-use-previous": "1.0.1",
+                "@radix-ui/react-visually-hidden": "1.0.3",
+                "aria-hidden": "^1.1.1",
+                "react-remove-scroll": "2.5.5"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0",
+                "react-dom": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-slot": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.2.tgz",
+            "integrity": "sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-compose-refs": "1.0.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-callback-ref": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz",
+            "integrity": "sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-controllable-state": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.1.tgz",
+            "integrity": "sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-use-callback-ref": "1.0.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-escape-keydown": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.3.tgz",
+            "integrity": "sha512-vyL82j40hcFicA+M4Ex7hVkB9vHgSse1ZWomAqV2Je3RleKGO5iM8KMOEtfoSB0PnIelMd2lATjTGMYqN5ylTg==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-use-callback-ref": "1.0.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-layout-effect": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz",
+            "integrity": "sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-previous": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.0.1.tgz",
+            "integrity": "sha512-cV5La9DPwiQ7S0gf/0qiD6YgNqM5Fk97Kdrlc5yBcrF3jyEZQwm7vYFqMo4IfeHgJXsRaMvLABFtd0OVEmZhDw==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-rect": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.0.1.tgz",
+            "integrity": "sha512-Cq5DLuSiuYVKNU8orzJMbl15TXilTnJKUCltMVQg53BQOF1/C5toAaGrowkgksdBQ9H+SRL23g0HDmg9tvmxXw==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/rect": "1.0.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-size": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.0.1.tgz",
+            "integrity": "sha512-ibay+VqrgcaI6veAojjofPATwledXiSmX+C0KrBk/xgpX9rBzPV3OsfwlhQdUOFbh+LKQorLYT+xTXW9V8yd0g==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-use-layout-effect": "1.0.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-visually-hidden": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.0.3.tgz",
+            "integrity": "sha512-D4w41yN5YRKtu464TLnByKzMDG/JlMPHtfZgQAu9v6mNakUqGUI9vUrfQKz8NK41VMm/xbZbh76NUTVtIYqOMA==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-primitive": "1.0.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0",
+                "react-dom": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/rect": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.0.1.tgz",
+            "integrity": "sha512-fyrgCaedtvMg9NK3en0pnOYJdtfwxUcNolezkNPUsoX57X8oQk+NkqcvzHXD2uKNij6GXmWU9NDru2IWjrO4BQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10"
             }
         },
         "node_modules/@swc/helpers": {
@@ -311,14 +901,12 @@
         "node_modules/any-promise": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-            "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-            "dev": true
+            "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
         },
         "node_modules/anymatch": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
             "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-            "dev": true,
             "dependencies": {
                 "normalize-path": "^3.0.0",
                 "picomatch": "^2.0.4"
@@ -330,8 +918,18 @@
         "node_modules/arg": {
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-            "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-            "dev": true
+            "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
+        },
+        "node_modules/aria-hidden": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.3.tgz",
+            "integrity": "sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==",
+            "dependencies": {
+                "tslib": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/autoprefixer": {
             "version": "10.4.16",
@@ -373,14 +971,12 @@
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
         },
         "node_modules/binary-extensions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
             "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -389,7 +985,6 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -399,7 +994,6 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
             "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-            "dev": true,
             "dependencies": {
                 "fill-range": "^7.0.1"
             },
@@ -462,7 +1056,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
             "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-            "dev": true,
             "engines": {
                 "node": ">= 6"
             }
@@ -490,7 +1083,6 @@
             "version": "3.5.3",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
             "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -517,12 +1109,22 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-            "dev": true,
             "dependencies": {
                 "is-glob": "^4.0.1"
             },
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/class-variance-authority": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.0.tgz",
+            "integrity": "sha512-jFI8IQw4hczaL4ALINxqLEXQbWcNjoSkloa4IaufXCJr6QawJyw7tuRysRsrE8w2p/4gGaxKIt/hX3qz/IbD1A==",
+            "dependencies": {
+                "clsx": "2.0.0"
+            },
+            "funding": {
+                "url": "https://joebell.co.uk"
             }
         },
         "node_modules/classnames": {
@@ -547,7 +1149,6 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
             "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-            "dev": true,
             "engines": {
                 "node": ">= 6"
             }
@@ -555,19 +1156,32 @@
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-            "dev": true
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
         },
         "node_modules/cssesc": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
             "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-            "dev": true,
             "bin": {
                 "cssesc": "bin/cssesc"
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/date-fns": {
+            "version": "2.30.0",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+            "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+            "dependencies": {
+                "@babel/runtime": "^7.21.0"
+            },
+            "engines": {
+                "node": ">=0.11"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/date-fns"
             }
         },
         "node_modules/debug": {
@@ -591,17 +1205,20 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
+        "node_modules/detect-node-es": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+            "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
+        },
         "node_modules/didyoumean": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
-            "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-            "dev": true
+            "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
         },
         "node_modules/dlv": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-            "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-            "dev": true
+            "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
         },
         "node_modules/electron-to-chromium": {
             "version": "1.4.578",
@@ -627,7 +1244,6 @@
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
             "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
-            "dev": true,
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
                 "@nodelib/fs.walk": "^1.2.3",
@@ -643,7 +1259,6 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-            "dev": true,
             "dependencies": {
                 "is-glob": "^4.0.1"
             },
@@ -655,7 +1270,6 @@
             "version": "1.15.0",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
             "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
-            "dev": true,
             "dependencies": {
                 "reusify": "^1.0.4"
             }
@@ -664,7 +1278,6 @@
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
             "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-            "dev": true,
             "dependencies": {
                 "to-regex-range": "^5.0.1"
             },
@@ -688,14 +1301,12 @@
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-            "dev": true
+            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
         },
         "node_modules/fsevents": {
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
             "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-            "dev": true,
             "hasInstallScript": true,
             "optional": true,
             "os": [
@@ -709,16 +1320,22 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
             "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-            "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-nonce": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+            "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/glob": {
             "version": "7.1.6",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
             "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-            "dev": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -738,7 +1355,6 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
             "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-            "dev": true,
             "dependencies": {
                 "is-glob": "^4.0.3"
             },
@@ -760,7 +1376,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
             "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
-            "dev": true,
             "dependencies": {
                 "function-bind": "^1.1.2"
             },
@@ -772,7 +1387,6 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-            "dev": true,
             "dependencies": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -781,14 +1395,20 @@
         "node_modules/inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "node_modules/invariant": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+            "dependencies": {
+                "loose-envify": "^1.0.0"
+            }
         },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
             "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-            "dev": true,
             "dependencies": {
                 "binary-extensions": "^2.0.0"
             },
@@ -800,7 +1420,6 @@
             "version": "2.13.1",
             "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
             "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
-            "dev": true,
             "dependencies": {
                 "hasown": "^2.0.0"
             },
@@ -812,7 +1431,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -821,7 +1439,6 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "dev": true,
             "dependencies": {
                 "is-extglob": "^2.1.1"
             },
@@ -833,7 +1450,6 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-            "dev": true,
             "engines": {
                 "node": ">=0.12.0"
             }
@@ -842,7 +1458,6 @@
             "version": "1.21.0",
             "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
             "integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
-            "dev": true,
             "bin": {
                 "jiti": "bin/jiti.js"
             }
@@ -878,7 +1493,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
             "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
-            "dev": true,
             "engines": {
                 "node": ">=10"
             }
@@ -886,8 +1500,7 @@
         "node_modules/lines-and-columns": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-            "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-            "dev": true
+            "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
         },
         "node_modules/lodash.debounce": {
             "version": "4.0.8",
@@ -905,6 +1518,14 @@
                 "loose-envify": "cli.js"
             }
         },
+        "node_modules/lucide-react": {
+            "version": "0.292.0",
+            "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.292.0.tgz",
+            "integrity": "sha512-rRgUkpEHWpa5VCT66YscInCQmQuPCB1RFRzkkxMxg4b+jaL0V12E3riWWR2Sh5OIiUhCwGW/ZExuEO4Az32E6Q==",
+            "peerDependencies": {
+                "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
+            }
+        },
         "node_modules/memory-pager": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
@@ -914,7 +1535,6 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-            "dev": true,
             "engines": {
                 "node": ">= 8"
             }
@@ -923,7 +1543,6 @@
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
             "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-            "dev": true,
             "dependencies": {
                 "braces": "^3.0.2",
                 "picomatch": "^2.3.1"
@@ -936,7 +1555,6 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-            "dev": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -1047,7 +1665,6 @@
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
             "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-            "dev": true,
             "dependencies": {
                 "any-promise": "^1.0.0",
                 "object-assign": "^4.0.1",
@@ -1126,7 +1743,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -1144,7 +1760,6 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -1153,7 +1768,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
             "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-            "dev": true,
             "engines": {
                 "node": ">= 6"
             }
@@ -1162,7 +1776,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-            "dev": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -1171,7 +1784,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -1179,8 +1791,7 @@
         "node_modules/path-parse": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-            "dev": true
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
         },
         "node_modules/picocolors": {
             "version": "1.0.0",
@@ -1191,7 +1802,6 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
             "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-            "dev": true,
             "engines": {
                 "node": ">=8.6"
             },
@@ -1203,7 +1813,6 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
             "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -1212,7 +1821,6 @@
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
             "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
-            "dev": true,
             "engines": {
                 "node": ">= 6"
             }
@@ -1248,7 +1856,6 @@
             "version": "15.1.0",
             "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
             "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-            "dev": true,
             "dependencies": {
                 "postcss-value-parser": "^4.0.0",
                 "read-cache": "^1.0.0",
@@ -1265,7 +1872,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
             "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
-            "dev": true,
             "dependencies": {
                 "camelcase-css": "^2.0.1"
             },
@@ -1284,7 +1890,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.1.tgz",
             "integrity": "sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==",
-            "dev": true,
             "dependencies": {
                 "lilconfig": "^2.0.5",
                 "yaml": "^2.1.1"
@@ -1313,7 +1918,6 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.0.1.tgz",
             "integrity": "sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==",
-            "dev": true,
             "dependencies": {
                 "postcss-selector-parser": "^6.0.11"
             },
@@ -1332,7 +1936,6 @@
             "version": "6.0.13",
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
             "integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
-            "dev": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -1344,8 +1947,7 @@
         "node_modules/postcss-value-parser": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-            "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-            "dev": true
+            "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
         },
         "node_modules/punycode": {
             "version": "2.3.1",
@@ -1359,7 +1961,6 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -1386,6 +1987,19 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/react-day-picker": {
+            "version": "8.9.1",
+            "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.9.1.tgz",
+            "integrity": "sha512-W0SPApKIsYq+XCtfGeMYDoU0KbsG3wfkYtlw8l+vZp6KoBXGOlhzBUp4tNx1XiwiOZwhfdGOlj7NGSCKGSlg5Q==",
+            "funding": {
+                "type": "individual",
+                "url": "https://github.com/sponsors/gpbl"
+            },
+            "peerDependencies": {
+                "date-fns": "^2.28.0",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
         "node_modules/react-dom": {
             "version": "18.2.0",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -1406,6 +2020,51 @@
                 "react": "*"
             }
         },
+        "node_modules/react-remove-scroll": {
+            "version": "2.5.5",
+            "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz",
+            "integrity": "sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==",
+            "dependencies": {
+                "react-remove-scroll-bar": "^2.3.3",
+                "react-style-singleton": "^2.2.1",
+                "tslib": "^2.1.0",
+                "use-callback-ref": "^1.3.0",
+                "use-sidecar": "^1.1.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/react-remove-scroll-bar": {
+            "version": "2.3.4",
+            "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz",
+            "integrity": "sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==",
+            "dependencies": {
+                "react-style-singleton": "^2.2.1",
+                "tslib": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/react-slick": {
             "version": "0.29.0",
             "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.29.0.tgz",
@@ -1422,11 +2081,32 @@
                 "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0"
             }
         },
+        "node_modules/react-style-singleton": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
+            "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
+            "dependencies": {
+                "get-nonce": "^1.0.0",
+                "invariant": "^2.2.4",
+                "tslib": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/read-cache": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
             "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-            "dev": true,
             "dependencies": {
                 "pify": "^2.3.0"
             }
@@ -1435,7 +2115,6 @@
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
             "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-            "dev": true,
             "dependencies": {
                 "picomatch": "^2.2.1"
             },
@@ -1457,7 +2136,6 @@
             "version": "1.22.8",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
             "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-            "dev": true,
             "dependencies": {
                 "is-core-module": "^2.13.0",
                 "path-parse": "^1.0.7",
@@ -1474,7 +2152,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
             "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-            "dev": true,
             "engines": {
                 "iojs": ">=1.0.0",
                 "node": ">=0.10.0"
@@ -1484,7 +2161,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
             "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -1579,7 +2255,6 @@
             "version": "3.34.0",
             "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.34.0.tgz",
             "integrity": "sha512-70/LQEZ07TEcxiU2dz51FKaE6hCTWC6vr7FOk3Gr0U60C3shtAN+H+BFr9XlYe5xqf3RA8nrc+VIwzCfnxuXJw==",
-            "dev": true,
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.2",
                 "commander": "^4.0.0",
@@ -1601,7 +2276,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
             "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -1625,7 +2299,6 @@
             "version": "3.3.5",
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.5.tgz",
             "integrity": "sha512-5SEZU4J7pxZgSkv7FP1zY8i2TIAOooNZ1e/OGtxIEv6GltpoiXUqWvLy89+a10qYTB1N5Ifkuw9lqQkN9sscvA==",
-            "dev": true,
             "dependencies": {
                 "@alloc/quick-lru": "^5.2.0",
                 "arg": "^5.0.2",
@@ -1658,11 +2331,18 @@
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/tailwindcss-animate": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
+            "integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
+            "peerDependencies": {
+                "tailwindcss": ">=3.0.0 || insiders"
+            }
+        },
         "node_modules/thenify": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
             "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-            "dev": true,
             "dependencies": {
                 "any-promise": "^1.0.0"
             }
@@ -1671,7 +2351,6 @@
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
             "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-            "dev": true,
             "dependencies": {
                 "thenify": ">= 3.1.0 < 4"
             },
@@ -1683,7 +2362,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-            "dev": true,
             "dependencies": {
                 "is-number": "^7.0.0"
             },
@@ -1705,8 +2383,7 @@
         "node_modules/ts-interface-checker": {
             "version": "0.1.13",
             "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
-            "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-            "dev": true
+            "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
         },
         "node_modules/tslib": {
             "version": "2.6.2",
@@ -1748,11 +2425,51 @@
                 "browserslist": ">= 4.21.0"
             }
         },
+        "node_modules/use-callback-ref": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
+            "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
+            "dependencies": {
+                "tslib": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/use-sidecar": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
+            "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+            "dependencies": {
+                "detect-node-es": "^1.1.0",
+                "tslib": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "@types/react": "^16.9.0 || ^17.0.0 || ^18.0.0",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-            "dev": true
+            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
         },
         "node_modules/watchpack": {
             "version": "2.4.0",
@@ -1789,14 +2506,12 @@
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "dev": true
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
         },
         "node_modules/yaml": {
             "version": "2.3.4",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
             "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
-            "dev": true,
             "engines": {
                 "node": ">= 14"
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
                 "@radix-ui/react-popover": "^1.0.7",
                 "@radix-ui/react-select": "^2.0.0",
                 "@radix-ui/react-slot": "^1.0.2",
+                "@radix-ui/react-toast": "^1.1.5",
                 "bcryptjs": "^2.4.3",
                 "class-variance-authority": "^0.7.0",
                 "clsx": "^2.0.0",
@@ -1143,6 +1144,40 @@
             },
             "peerDependenciesMeta": {
                 "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-toast": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.1.5.tgz",
+            "integrity": "sha512-fRLn227WHIBRSzuRzGJ8W+5YALxofH23y0MlPLddaIpLpCDqdE0NZlS2NRQDRiptfxDeeCjgFIpexB1/zkxDlw==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/primitive": "1.0.1",
+                "@radix-ui/react-collection": "1.0.3",
+                "@radix-ui/react-compose-refs": "1.0.1",
+                "@radix-ui/react-context": "1.0.1",
+                "@radix-ui/react-dismissable-layer": "1.0.5",
+                "@radix-ui/react-portal": "1.0.4",
+                "@radix-ui/react-presence": "1.0.1",
+                "@radix-ui/react-primitive": "1.0.3",
+                "@radix-ui/react-use-callback-ref": "1.0.1",
+                "@radix-ui/react-use-controllable-state": "1.0.1",
+                "@radix-ui/react-use-layout-effect": "1.0.1",
+                "@radix-ui/react-visually-hidden": "1.0.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0",
+                "react-dom": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
                     "optional": true
                 }
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
                 "react": "^18",
                 "react-day-picker": "^8.9.1",
                 "react-dom": "^18",
+                "react-google-autocomplete": "^2.7.3",
                 "react-icons": "^4.11.0",
                 "react-slick": "^0.29.0",
                 "slick-carousel": "^1.8.1",
@@ -2853,6 +2854,18 @@
             },
             "peerDependencies": {
                 "react": "^18.2.0"
+            }
+        },
+        "node_modules/react-google-autocomplete": {
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/react-google-autocomplete/-/react-google-autocomplete-2.7.3.tgz",
+            "integrity": "sha512-Nm+7/VDe7/NDWb8p/a39is7ktNqt5bNqAOoQv2Ev/XkuEvjsRk08VAPFmXUH03xKuM8IUuDrk2Lwfge44YEj6Q==",
+            "dependencies": {
+                "lodash.debounce": "^4.0.8",
+                "prop-types": "^15.5.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0"
             }
         },
         "node_modules/react-icons": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "sublet-webapp-next",
+    "name": "coleaseum-webapp",
     "version": "0.1.0",
     "private": true,
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "react": "^18",
         "react-day-picker": "^8.9.1",
         "react-dom": "^18",
+        "react-google-autocomplete": "^2.7.3",
         "react-icons": "^4.11.0",
         "react-slick": "^0.29.0",
         "slick-carousel": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -9,12 +9,18 @@
         "lint": "next lint"
     },
     "dependencies": {
+        "@emotion/react": "^11.11.1",
+        "@emotion/styled": "^11.11.0",
+        "@mui/material": "^5.14.18",
         "@radix-ui/react-popover": "^1.0.7",
         "@radix-ui/react-select": "^2.0.0",
         "@radix-ui/react-slot": "^1.0.2",
+        "bcryptjs": "^2.4.3",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.0.0",
         "date-fns": "^2.30.0",
+        "jsonwebtoken": "^9.0.2",
+        "jwt-decode": "^4.0.0",
         "lucide-react": "^0.292.0",
         "mongoose": "^8.0.0",
         "next": "14.0.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "@radix-ui/react-popover": "^1.0.7",
         "@radix-ui/react-select": "^2.0.0",
         "@radix-ui/react-slot": "^1.0.2",
+        "@radix-ui/react-toast": "^1.1.5",
         "bcryptjs": "^2.4.3",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -9,15 +9,23 @@
         "lint": "next lint"
     },
     "dependencies": {
+        "@radix-ui/react-popover": "^1.0.7",
+        "@radix-ui/react-select": "^2.0.0",
+        "@radix-ui/react-slot": "^1.0.2",
+        "class-variance-authority": "^0.7.0",
         "clsx": "^2.0.0",
+        "date-fns": "^2.30.0",
+        "lucide-react": "^0.292.0",
         "mongoose": "^8.0.0",
         "next": "14.0.1",
         "react": "^18",
+        "react-day-picker": "^8.9.1",
         "react-dom": "^18",
         "react-icons": "^4.11.0",
         "react-slick": "^0.29.0",
         "slick-carousel": "^1.8.1",
-        "tailwind-merge": "^2.0.0"
+        "tailwind-merge": "^2.0.0",
+        "tailwindcss-animate": "^1.0.7"
     },
     "devDependencies": {
         "autoprefixer": "^10.0.1",

--- a/src/components/AuthInput.js
+++ b/src/components/AuthInput.js
@@ -1,11 +1,13 @@
 import React from "react";
 import Input from "@/components/Input";
+import { cn } from "@/utils/utils";
 
 // input component to be used for auth forms etc.
 // provides functionality for error messages and error styling
-const AuthInput = ({ error, touched, ...props }) => {
+const AuthInput = ({ title = "test", error, touched, className, ...props }) => {
     return (
-        <div className="flex flex-col">
+        <div className={cn("flex flex-col", className)}>
+            <label className="text-base font-medium text-slate-900 mb-1 ml-0">{title}</label>
             <Input className={touched && error ? "border-red-500" : ""} {...props} />
             {touched && error && <p className="text-sm ml-3 mt-1 text-red-500">{error}</p>}
         </div>

--- a/src/components/AuthInput.js
+++ b/src/components/AuthInput.js
@@ -4,7 +4,7 @@ import { cn } from "@/utils/utils";
 
 // input component to be used for auth forms etc.
 // provides functionality for error messages and error styling
-const AuthInput = ({ title = "test", error, touched, className, ...props }) => {
+const AuthInput = ({ title, error, touched, className, ...props }) => {
     return (
         <div className={cn("flex flex-col", className)}>
             <label className="text-base font-medium text-slate-900 mb-1 ml-0">{title}</label>

--- a/src/components/AuthInput.js
+++ b/src/components/AuthInput.js
@@ -1,0 +1,15 @@
+import React from "react";
+import Input from "@/components/Input";
+
+// input component to be used for auth forms etc.
+// provides functionality for error messages and error styling
+const AuthInput = ({ error, touched, ...props }) => {
+    return (
+        <div className="flex flex-col">
+            <Input className={touched && error ? "border-red-500" : ""} {...props} />
+            {touched && error && <p className="text-sm ml-3 mt-1 text-red-500">{error}</p>}
+        </div>
+    );
+};
+
+export default AuthInput;

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,0 +1,20 @@
+import React from "react";
+import { cn } from "@/utils/utils";
+
+// simple button component, just a wrapper around <button>
+// propagtes all props and tailwind classes, just adds some styling
+const Button = ({ className, children, ...props }) => {
+    return (
+        <button
+            className={cn(
+                "text-base inline-flex items-center justify-center h-11 px-8 py-2 rounded-md bg-black text-white cursor-pointer",
+                className
+            )}
+            {...props}
+        >
+            {children}
+        </button>
+    );
+};
+
+export default Button;

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -65,7 +65,7 @@ const MonthPicker = ({ selectedMonth, setSelectedMonth }) => {
     );
 };
 
-const DatePicker = ({ formData, setFormData }) => {
+const DatePicker = ({ formData, setFormData, className }) => {
     const [date, setDate] = useState(null);
     const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
     const [selectedMonth, setSelectedMonth] = useState(new Date().getMonth());
@@ -94,8 +94,7 @@ const DatePicker = ({ formData, setFormData }) => {
     };
 
     const handleDateSelect = (date) => {
-        // just a temp function for now so I can console log the chosen date
-        console.log(format(date, "PPP"));
+        // console.log(format(date, "PPP"));
         // console.log(format(date, "yyyy-MM-dd"));
         setDate(date);
         setFormData({ ...formData, dateOfBirth: date });
@@ -108,7 +107,8 @@ const DatePicker = ({ formData, setFormData }) => {
                     variant={"outline"}
                     className={cn(
                         "w-full h-11 justify-start text-left font-normal border-slate-300",
-                        !date && "text-muted-foreground"
+                        !date && "text-muted-foreground",
+                        className
                     )}
                 >
                     <CalendarIcon className="mr-2 h-4 w-4" />
@@ -126,7 +126,6 @@ const DatePicker = ({ formData, setFormData }) => {
                 <Calendar
                     mode="single"
                     selected={date}
-                    // onSelect={setDate}
                     onSelect={handleDateSelect}
                     displayDate={popoverDisplayDate}
                     setDisplayDate={setPopoverDisplayDate}

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -1,0 +1,107 @@
+import React, { useState } from "react";
+import { format } from "date-fns";
+import { Calendar as CalendarIcon } from "lucide-react";
+
+import { cn } from "@/utils/utils";
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+
+const YearPicker = ({ selectedYear, setSelectedYear }) => {
+    const years = Array.from({ length: 100 }, (_, i) => new Date().getFullYear() - i);
+
+    return (
+        <select
+            value={selectedYear}
+            onChange={(e) => setSelectedYear(parseInt(e.target.value, 10))}
+        >
+            {years.map((year) => (
+                <option key={year} value={year}>
+                    {year}
+                </option>
+            ))}
+        </select>
+    );
+};
+
+const YearPicker2 = ({ selectedYear, setSelectedYear }) => {
+    const years = Array.from({ length: 100 }, (_, i) => new Date().getFullYear() - i);
+
+    return (
+        <Select onValueChange={(value) => setSelectedYear(parseInt(value, 10))}>
+            <SelectTrigger>
+                <SelectValue placeholder={selectedYear} />
+            </SelectTrigger>
+            <SelectContent>
+                {years.map((year) => (
+                    <SelectItem key={year} value={String(year)}>
+                        {year}
+                    </SelectItem>
+                ))}
+            </SelectContent>
+        </Select>
+    );
+};
+
+const DatePicker = () => {
+    const [date, setDate] = useState(null);
+    const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
+    const [popoverDisplayDate, setPopoverDisplayDate] = useState(new Date());
+
+    const handleYearChange = (year) => {
+        setSelectedYear(year);
+        if (date) {
+            const newDate = new Date(year, date.getMonth(), date.getDate());
+            setDate(newDate);
+            setPopoverDisplayDate(newDate);
+        } else {
+            setPopoverDisplayDate(new Date(year, popoverDisplayDate.getMonth()));
+        }
+    };
+
+    const handleDateSelect = (date) => {
+        // just a temp function for now so I can console log the chosen date
+        console.log(date);
+        setDate(date);
+    };
+
+    return (
+        <Popover>
+            <PopoverTrigger asChild>
+                <Button
+                    variant={"outline"}
+                    className={cn(
+                        "w-full h-11 justify-start text-left font-normal border-slate-300",
+                        !date && "text-muted-foreground"
+                    )}
+                >
+                    <CalendarIcon className="mr-2 h-4 w-4" />
+                    {date ? format(date, "PPP") : <span>Pick a date</span>}
+                </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-auto p-0 flex flex-col items-center">
+                <div className="p-2">
+                    <YearPicker2 selectedYear={selectedYear} setSelectedYear={handleYearChange} />
+                </div>
+                <Calendar
+                    mode="single"
+                    selected={date}
+                    // onSelect={setDate}
+                    onSelect={handleDateSelect}
+                    displayDate={popoverDisplayDate}
+                    setDisplayDate={setPopoverDisplayDate}
+                    initialFocus
+                />
+            </PopoverContent>
+        </Popover>
+    );
+};
+
+export default DatePicker;

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -18,23 +18,6 @@ const YearPicker = ({ selectedYear, setSelectedYear }) => {
     const years = Array.from({ length: 100 }, (_, i) => new Date().getFullYear() - i);
 
     return (
-        <select
-            value={selectedYear}
-            onChange={(e) => setSelectedYear(parseInt(e.target.value, 10))}
-        >
-            {years.map((year) => (
-                <option key={year} value={year}>
-                    {year}
-                </option>
-            ))}
-        </select>
-    );
-};
-
-const YearPicker2 = ({ selectedYear, setSelectedYear }) => {
-    const years = Array.from({ length: 100 }, (_, i) => new Date().getFullYear() - i);
-
-    return (
         <Select onValueChange={(value) => setSelectedYear(parseInt(value, 10))}>
             <SelectTrigger>
                 <SelectValue placeholder={selectedYear} />
@@ -50,9 +33,42 @@ const YearPicker2 = ({ selectedYear, setSelectedYear }) => {
     );
 };
 
+const MonthPicker = ({ selectedMonth, setSelectedMonth }) => {
+    const months = [
+        "January",
+        "February",
+        "March",
+        "April",
+        "May",
+        "June",
+        "July",
+        "August",
+        "September",
+        "October",
+        "November",
+        "December",
+    ];
+
+    return (
+        <Select onValueChange={(value) => setSelectedMonth(months.indexOf(value))}>
+            <SelectTrigger>
+                <SelectValue placeholder={months[selectedMonth]} />
+            </SelectTrigger>
+            <SelectContent>
+                {months.map((month) => (
+                    <SelectItem key={month} value={month}>
+                        {month}
+                    </SelectItem>
+                ))}
+            </SelectContent>
+        </Select>
+    );
+};
+
 const DatePicker = () => {
     const [date, setDate] = useState(null);
     const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
+    const [selectedMonth, setSelectedMonth] = useState(new Date().getMonth());
     const [popoverDisplayDate, setPopoverDisplayDate] = useState(new Date());
 
     const handleYearChange = (year) => {
@@ -66,6 +82,17 @@ const DatePicker = () => {
         }
     };
 
+    const handleMonthChange = (month) => {
+        setSelectedMonth(month);
+        if (date) {
+            const newDate = new Date(date.getFullYear(), month, date.getDate());
+            setDate(newDate);
+            setPopoverDisplayDate(newDate);
+        } else {
+            setPopoverDisplayDate(new Date(popoverDisplayDate.getFullYear(), month));
+        }
+    };
+
     const handleDateSelect = (date) => {
         // just a temp function for now so I can console log the chosen date
         console.log(date);
@@ -73,7 +100,7 @@ const DatePicker = () => {
     };
 
     return (
-        <Popover>
+        <Popover side="bottom">
             <PopoverTrigger asChild>
                 <Button
                     variant={"outline"}
@@ -87,8 +114,12 @@ const DatePicker = () => {
                 </Button>
             </PopoverTrigger>
             <PopoverContent className="w-auto p-0 flex flex-col items-center">
-                <div className="p-2">
-                    <YearPicker2 selectedYear={selectedYear} setSelectedYear={handleYearChange} />
+                <div className="flex gap-2 p-2">
+                    <YearPicker selectedYear={selectedYear} setSelectedYear={handleYearChange} />
+                    <MonthPicker
+                        selectedMonth={selectedMonth}
+                        setSelectedMonth={handleMonthChange}
+                    />
                 </div>
                 <Calendar
                     mode="single"

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -65,7 +65,7 @@ const MonthPicker = ({ selectedMonth, setSelectedMonth }) => {
     );
 };
 
-const DatePicker = () => {
+const DatePicker = ({ formData, setFormData }) => {
     const [date, setDate] = useState(null);
     const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
     const [selectedMonth, setSelectedMonth] = useState(new Date().getMonth());
@@ -95,8 +95,10 @@ const DatePicker = () => {
 
     const handleDateSelect = (date) => {
         // just a temp function for now so I can console log the chosen date
-        console.log(date);
+        console.log(format(date, "PPP"));
+        // console.log(format(date, "yyyy-MM-dd"));
         setDate(date);
+        setFormData({ ...formData, dateOfBirth: date });
     };
 
     return (

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -1,0 +1,15 @@
+import React from "react";
+import { cn } from "@/utils/utils";
+
+// simple input component, just a wrapper around <input>
+// propagtes all props and tailwind classes, just adds some styling
+const Input = ({ className, ...props }) => {
+    return (
+        <input
+            className={cn("border border-slate-300 rounded-md w-full h-11 px-4 py-2", className)}
+            {...props}
+        />
+    );
+};
+
+export default Input;

--- a/src/components/ProfileImagePlaceholder.js
+++ b/src/components/ProfileImagePlaceholder.js
@@ -1,0 +1,12 @@
+import React from "react";
+import { FaUser } from "react-icons/fa6";
+
+const ProfileImagePlaceholder = () => {
+    return (
+        <div className="flex items-center justify-center w-20 h-20 rounded-full bg-slate-300">
+            <FaUser className="text-4xl text-white" />
+        </div>
+    );
+};
+
+export default ProfileImagePlaceholder;

--- a/src/components/ui/button.jsx
+++ b/src/components/ui/button.jsx
@@ -1,0 +1,47 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva } from "class-variance-authority";
+
+import { cn } from "@/utils/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+const Button = React.forwardRef(({ className, variant, size, asChild = false, ...props }, ref) => {
+  const Comp = asChild ? Slot : "button"
+  return (
+    (<Comp
+      className={cn(buttonVariants({ variant, size, className }))}
+      ref={ref}
+      {...props} />)
+  );
+})
+Button.displayName = "Button"
+
+export { Button, buttonVariants }

--- a/src/components/ui/calendar.jsx
+++ b/src/components/ui/calendar.jsx
@@ -1,0 +1,64 @@
+import * as React from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { DayPicker } from "react-day-picker";
+
+import { cn } from "@/utils/utils";
+import { buttonVariants } from "@/components/ui/button";
+
+function Calendar({
+    className,
+    classNames,
+    showOutsideDays = true,
+    displayDate,
+    setDisplayDate,
+    ...props
+}) {
+    return (
+        <DayPicker
+            month={displayDate}
+            onMonthChange={setDisplayDate}
+            showOutsideDays={showOutsideDays}
+            className={cn("p-3", className)}
+            classNames={{
+                months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
+                month: "space-y-4",
+                caption: "flex justify-center pt-1 relative items-center",
+                caption_label: "text-sm font-medium",
+                nav: "space-x-1 flex items-center",
+                nav_button: cn(
+                    buttonVariants({ variant: "outline" }),
+                    "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100"
+                ),
+                nav_button_previous: "absolute left-1",
+                nav_button_next: "absolute right-1",
+                table: "w-full border-collapse space-y-1",
+                head_row: "flex",
+                head_cell: "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]",
+                row: "flex w-full mt-2",
+                cell: "h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
+                day: cn(
+                    buttonVariants({ variant: "ghost" }),
+                    "h-9 w-9 p-0 font-normal aria-selected:opacity-100"
+                ),
+                day_range_end: "day-range-end",
+                day_selected:
+                    "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
+                day_today: "bg-accent text-accent-foreground",
+                day_outside:
+                    "day-outside text-muted-foreground opacity-50 aria-selected:bg-accent/50 aria-selected:text-muted-foreground aria-selected:opacity-30",
+                day_disabled: "text-muted-foreground opacity-50",
+                day_range_middle: "aria-selected:bg-accent aria-selected:text-accent-foreground",
+                day_hidden: "invisible",
+                ...classNames,
+            }}
+            components={{
+                IconLeft: ({ ...props }) => <ChevronLeft className="h-4 w-4" />,
+                IconRight: ({ ...props }) => <ChevronRight className="h-4 w-4" />,
+            }}
+            {...props}
+        />
+    );
+}
+Calendar.displayName = "Calendar";
+
+export { Calendar };

--- a/src/components/ui/popover.jsx
+++ b/src/components/ui/popover.jsx
@@ -1,0 +1,25 @@
+import * as React from "react"
+import * as PopoverPrimitive from "@radix-ui/react-popover"
+
+import { cn } from "@/utils/utils"
+
+const Popover = PopoverPrimitive.Root
+
+const PopoverTrigger = PopoverPrimitive.Trigger
+
+const PopoverContent = React.forwardRef(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props} />
+  </PopoverPrimitive.Portal>
+))
+PopoverContent.displayName = PopoverPrimitive.Content.displayName
+
+export { Popover, PopoverTrigger, PopoverContent }

--- a/src/components/ui/select.jsx
+++ b/src/components/ui/select.jsx
@@ -1,0 +1,120 @@
+import * as React from "react"
+import * as SelectPrimitive from "@radix-ui/react-select"
+import { Check, ChevronDown, ChevronUp } from "lucide-react"
+
+import { cn } from "@/utils/utils"
+
+const Select = SelectPrimitive.Root
+
+const SelectGroup = SelectPrimitive.Group
+
+const SelectValue = SelectPrimitive.Value
+
+const SelectTrigger = React.forwardRef(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      className
+    )}
+    {...props}>
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+))
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
+
+const SelectScrollUpButton = React.forwardRef(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn("flex cursor-default items-center justify-center py-1", className)}
+    {...props}>
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+))
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName
+
+const SelectScrollDownButton = React.forwardRef(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn("flex cursor-default items-center justify-center py-1", className)}
+    {...props}>
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+))
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName
+
+const SelectContent = React.forwardRef(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        className
+      )}
+      position={position}
+      {...props}>
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn("p-1", position === "popper" &&
+          "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]")}>
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+))
+SelectContent.displayName = SelectPrimitive.Content.displayName
+
+const SelectLabel = React.forwardRef(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)}
+    {...props} />
+))
+SelectLabel.displayName = SelectPrimitive.Label.displayName
+
+const SelectItem = React.forwardRef(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}>
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+))
+SelectItem.displayName = SelectPrimitive.Item.displayName
+
+const SelectSeparator = React.forwardRef(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props} />
+))
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
+}

--- a/src/components/ui/toast.jsx
+++ b/src/components/ui/toast.jsx
@@ -1,0 +1,103 @@
+import * as React from "react";
+import * as ToastPrimitives from "@radix-ui/react-toast";
+import { cva } from "class-variance-authority";
+import { X } from "lucide-react";
+
+import { cn } from "@/utils/utils";
+
+const ToastProvider = ToastPrimitives.Provider;
+
+const ToastViewport = React.forwardRef(({ className, ...props }, ref) => (
+    <ToastPrimitives.Viewport
+        ref={ref}
+        className={cn(
+            "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+            className
+        )}
+        {...props}
+    />
+));
+ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
+
+const toastVariants = cva(
+    "group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-top-full data-[state=closed]:sm:slide-out-to-bottom-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
+    {
+        variants: {
+            variant: {
+                default: "border bg-background text-foreground",
+                destructive:
+                    "destructive group border-destructive bg-destructive text-destructive-foreground",
+                success: "border-0 bg-green-500 text-white",
+            },
+        },
+        defaultVariants: {
+            variant: "default",
+        },
+    }
+);
+
+const Toast = React.forwardRef(({ className, variant, ...props }, ref) => {
+    return (
+        <ToastPrimitives.Root
+            ref={ref}
+            className={cn(toastVariants({ variant }), className)}
+            {...props}
+        />
+    );
+});
+Toast.displayName = ToastPrimitives.Root.displayName;
+
+const ToastAction = React.forwardRef(({ className, ...props }, ref) => (
+    <ToastPrimitives.Action
+        ref={ref}
+        className={cn(
+            "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
+            className
+        )}
+        {...props}
+    />
+));
+ToastAction.displayName = ToastPrimitives.Action.displayName;
+
+const ToastClose = React.forwardRef(({ className, ...props }, ref) => (
+    <ToastPrimitives.Close
+        ref={ref}
+        className={cn(
+            "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+            className
+        )}
+        toast-close=""
+        {...props}
+    >
+        <X className="h-4 w-4" />
+    </ToastPrimitives.Close>
+));
+ToastClose.displayName = ToastPrimitives.Close.displayName;
+
+const ToastTitle = React.forwardRef(({ className, ...props }, ref) => (
+    <ToastPrimitives.Title
+        ref={ref}
+        className={cn("text-sm font-semibold", className)}
+        {...props}
+    />
+));
+ToastTitle.displayName = ToastPrimitives.Title.displayName;
+
+const ToastDescription = React.forwardRef(({ className, ...props }, ref) => (
+    <ToastPrimitives.Description
+        ref={ref}
+        className={cn("text-sm opacity-90", className)}
+        {...props}
+    />
+));
+ToastDescription.displayName = ToastPrimitives.Description.displayName;
+
+export {
+    ToastProvider,
+    ToastViewport,
+    Toast,
+    ToastTitle,
+    ToastDescription,
+    ToastClose,
+    ToastAction,
+};

--- a/src/components/ui/toaster.jsx
+++ b/src/components/ui/toaster.jsx
@@ -1,0 +1,31 @@
+import {
+    Toast,
+    ToastClose,
+    ToastDescription,
+    ToastProvider,
+    ToastTitle,
+    ToastViewport,
+} from "@/components/ui/toast";
+import { useToast } from "@/components/ui/use-toast";
+
+export function Toaster() {
+    const { toasts } = useToast();
+
+    return (
+        <ToastProvider>
+            {toasts.map(function ({ id, title, description, action, ...props }) {
+                return (
+                    <Toast key={id} {...props}>
+                        <div className="grid gap-1">
+                            {title && <ToastTitle>{title}</ToastTitle>}
+                            {description && <ToastDescription>{description}</ToastDescription>}
+                        </div>
+                        {action}
+                        <ToastClose />
+                    </Toast>
+                );
+            })}
+            <ToastViewport />
+        </ToastProvider>
+    );
+}

--- a/src/components/ui/use-toast.js
+++ b/src/components/ui/use-toast.js
@@ -2,7 +2,7 @@
 import * as React from "react";
 
 const TOAST_LIMIT = 1;
-const TOAST_REMOVE_DELAY = 1000;
+const TOAST_REMOVE_DELAY = 2000;
 
 const actionTypes = {
     ADD_TOAST: "ADD_TOAST",
@@ -123,6 +123,11 @@ function toast({ ...props }) {
             },
         },
     });
+
+    // Automatically schedule a dismiss after TOAST_REMOVE_DELAY
+    setTimeout(() => {
+        dismiss();
+    }, TOAST_REMOVE_DELAY);
 
     return {
         id: id,

--- a/src/components/ui/use-toast.js
+++ b/src/components/ui/use-toast.js
@@ -1,0 +1,154 @@
+// Inspired by react-hot-toast library
+import * as React from "react";
+
+const TOAST_LIMIT = 1;
+const TOAST_REMOVE_DELAY = 1000;
+
+const actionTypes = {
+    ADD_TOAST: "ADD_TOAST",
+    UPDATE_TOAST: "UPDATE_TOAST",
+    DISMISS_TOAST: "DISMISS_TOAST",
+    REMOVE_TOAST: "REMOVE_TOAST",
+};
+
+let count = 0;
+
+function genId() {
+    count = (count + 1) % Number.MAX_VALUE;
+    return count.toString();
+}
+
+const toastTimeouts = new Map();
+
+const addToRemoveQueue = (toastId) => {
+    if (toastTimeouts.has(toastId)) {
+        return;
+    }
+
+    const timeout = setTimeout(() => {
+        toastTimeouts.delete(toastId);
+        dispatch({
+            type: "REMOVE_TOAST",
+            toastId: toastId,
+        });
+    }, TOAST_REMOVE_DELAY);
+
+    toastTimeouts.set(toastId, timeout);
+};
+
+export const reducer = (state, action) => {
+    switch (action.type) {
+        case "ADD_TOAST":
+            return {
+                ...state,
+                toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
+            };
+
+        case "UPDATE_TOAST":
+            return {
+                ...state,
+                toasts: state.toasts.map((t) =>
+                    t.id === action.toast.id ? { ...t, ...action.toast } : t
+                ),
+            };
+
+        case "DISMISS_TOAST": {
+            const { toastId } = action;
+
+            // ! Side effects ! - This could be extracted into a dismissToast() action,
+            // but I'll keep it here for simplicity
+            if (toastId) {
+                addToRemoveQueue(toastId);
+            } else {
+                state.toasts.forEach((toast) => {
+                    addToRemoveQueue(toast.id);
+                });
+            }
+
+            return {
+                ...state,
+                toasts: state.toasts.map((t) =>
+                    t.id === toastId || toastId === undefined
+                        ? {
+                              ...t,
+                              open: false,
+                          }
+                        : t
+                ),
+            };
+        }
+        case "REMOVE_TOAST":
+            if (action.toastId === undefined) {
+                return {
+                    ...state,
+                    toasts: [],
+                };
+            }
+            return {
+                ...state,
+                toasts: state.toasts.filter((t) => t.id !== action.toastId),
+            };
+    }
+};
+
+const listeners = [];
+
+let memoryState = { toasts: [] };
+
+function dispatch(action) {
+    memoryState = reducer(memoryState, action);
+    listeners.forEach((listener) => {
+        listener(memoryState);
+    });
+}
+
+function toast({ ...props }) {
+    const id = genId();
+
+    const update = (props) =>
+        dispatch({
+            type: "UPDATE_TOAST",
+            toast: { ...props, id },
+        });
+    const dismiss = () => dispatch({ type: "DISMISS_TOAST", toastId: id });
+
+    dispatch({
+        type: "ADD_TOAST",
+        toast: {
+            ...props,
+            id,
+            open: true,
+            onOpenChange: (open) => {
+                if (!open) dismiss();
+            },
+        },
+    });
+
+    return {
+        id: id,
+        dismiss,
+        update,
+    };
+}
+
+function useToast() {
+    const [state, setState] = React.useState(memoryState);
+
+    React.useEffect(() => {
+        listeners.push(setState);
+        return () => {
+            const index = listeners.indexOf(setState);
+            if (index > -1) {
+                listeners.splice(index, 1);
+            }
+        };
+    }, [state]);
+
+    return {
+        ...state,
+        toast,
+        dismiss: (toastId) => dispatch({ type: "DISMISS_TOAST", toastId }),
+    };
+}
+
+export { useToast, toast };

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -1,0 +1,32 @@
+import React, { createContext, useState, useEffect } from "react";
+
+export const AuthContext = createContext();
+
+export const AuthProvider = ({ children }) => {
+    const [user, setUser] = useState(null);
+    const [loading, setLoading] = useState(true); // helpful to update the UI accordingly
+
+    // check for user in local storage
+    useEffect(() => {
+        const loggedInUser = localStorage.getItem("user");
+        if (loggedInUser) {
+            setUser(JSON.parse(loggedInUser));
+        }
+        setLoading(false);
+    }, []);
+
+    // logout function
+    const logout = () => {
+        // Remove user from local storage
+        localStorage.removeItem("user");
+
+        // Remove user from context
+        setUser(null);
+    };
+
+    return (
+        <AuthContext.Provider value={{ user, setUser, loading, logout }}>
+            {children}
+        </AuthContext.Provider>
+    );
+};

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -6,7 +6,7 @@ export const AuthProvider = ({ children }) => {
     const [user, setUser] = useState(null);
     const [loading, setLoading] = useState(true); // helpful to update the UI accordingly
 
-    // check for user in local storage
+    // check for user in local storage on load
     useEffect(() => {
         const loggedInUser = localStorage.getItem("user");
         if (loggedInUser) {
@@ -15,8 +15,17 @@ export const AuthProvider = ({ children }) => {
         setLoading(false);
     }, []);
 
-    // logout function
-    const logout = () => {
+    // function to save user to local storage and context
+    const saveUser = (user) => {
+        // save user to local storage
+        localStorage.setItem("user", JSON.stringify(user));
+
+        // save user to context
+        setUser(user);
+    };
+
+    // sign out function
+    const signOut = () => {
         // Remove user from local storage
         localStorage.removeItem("user");
 
@@ -25,7 +34,7 @@ export const AuthProvider = ({ children }) => {
     };
 
     return (
-        <AuthContext.Provider value={{ user, setUser, loading, logout }}>
+        <AuthContext.Provider value={{ user, saveUser, loading, signOut }}>
             {children}
         </AuthContext.Provider>
     );

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,0 +1,6 @@
+import { useContext } from "react";
+import { AuthContext } from "@/context/AuthContext";
+
+export const useAuth = () => {
+    return useContext(AuthContext);
+};

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -2,7 +2,12 @@ import "@/styles/globals.css";
 import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
 import "@/styles/CarouselElement.css";
+import { AuthProvider } from "@/context/AuthContext";
 
 export default function App({ Component, pageProps }) {
-    return <Component {...pageProps} />;
+    return (
+        <AuthProvider>
+            <Component {...pageProps} />
+        </AuthProvider>
+    );
 }

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -3,11 +3,13 @@ import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
 import "@/styles/CarouselElement.css";
 import { AuthProvider } from "@/context/AuthContext";
+import { Toaster } from "@/components/ui/toaster";
 
 export default function App({ Component, pageProps }) {
     return (
         <AuthProvider>
             <Component {...pageProps} />
+            <Toaster />
         </AuthProvider>
     );
 }

--- a/src/pages/api/auth/signin.js
+++ b/src/pages/api/auth/signin.js
@@ -15,13 +15,13 @@ export default async function handler(req, res) {
                 // check if user exists
                 let user = await User.findOne({ email });
                 if (!user) {
-                    return res.status(400).json({ success: false, message: "Invalid Credentials" });
+                    return res.status(400).json({ error: "Email or password is incorrect" });
                 }
 
                 // compare password
                 const isMatch = await bcrypt.compare(password, user.password);
                 if (!isMatch) {
-                    return res.status(400).json({ success: false, message: "Invalid Credentials" });
+                    return res.status(400).json({ error: "Email or password is incorrect" });
                 }
 
                 // jwt payload
@@ -34,14 +34,19 @@ export default async function handler(req, res) {
                 // create, sign and return token
                 jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: "1h" }, (err, token) => {
                     if (err) throw err;
-                    res.status(200).json({ success: true, token });
+                    res.status(200).json({ token });
                 });
             } catch (error) {
-                res.status(400).json({ success: false });
+                // will have to change this error message in prod, since I'm taking the
+                // error message from this response and displaying it on the frontend
+                // or maybe we change how it works on the frontend idk but this is gonna
+                // have to be addressed eventually.
+                res.status(500).json({ error: `APIError: Sign in failed.\n${error}` });
             }
             break;
         default:
-            res.status(400).json({ success: false });
+            res.setHeader("Allow", ["POST"]);
+            res.status(405).json({ error: `Method ${req.method} Not Allowed` });
             break;
     }
 }

--- a/src/pages/api/auth/signin.js
+++ b/src/pages/api/auth/signin.js
@@ -1,0 +1,47 @@
+import bcrypt from "bcryptjs";
+import jwt from "jsonwebtoken";
+import User from "@/models/User";
+import connectMongo from "@/utils/connectMongo";
+
+export default async function handler(req, res) {
+    // connect to DB
+    await connectMongo();
+
+    switch (req.method) {
+        case "POST":
+            try {
+                const { email, password } = req.body;
+
+                // check if user exists
+                let user = await User.findOne({ email });
+                if (!user) {
+                    return res.status(400).json({ success: false, message: "Invalid Credentials" });
+                }
+
+                // compare password
+                const isMatch = await bcrypt.compare(password, user.password);
+                if (!isMatch) {
+                    return res.status(400).json({ success: false, message: "Invalid Credentials" });
+                }
+
+                // jwt payload
+                const payload = {
+                    user: {
+                        id: user.id,
+                    },
+                };
+
+                // create, sign and return token
+                jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: "1h" }, (err, token) => {
+                    if (err) throw err;
+                    res.status(200).json({ success: true, token });
+                });
+            } catch (error) {
+                res.status(400).json({ success: false });
+            }
+            break;
+        default:
+            res.status(400).json({ success: false });
+            break;
+    }
+}

--- a/src/pages/api/auth/signin.js
+++ b/src/pages/api/auth/signin.js
@@ -15,13 +15,13 @@ export default async function handler(req, res) {
                 // check if user exists
                 let user = await User.findOne({ email });
                 if (!user) {
-                    return res.status(400).json({ error: "Email or password is incorrect" });
+                    return res.status(400).json({ error: "Incorrect email or password." });
                 }
 
                 // compare password
                 const isMatch = await bcrypt.compare(password, user.password);
                 if (!isMatch) {
-                    return res.status(400).json({ error: "Email or password is incorrect" });
+                    return res.status(400).json({ error: "Incorrect email or password." });
                 }
 
                 // jwt payload

--- a/src/pages/api/auth/signup.js
+++ b/src/pages/api/auth/signup.js
@@ -49,7 +49,7 @@ export default async function handler(req, res) {
                 });
 
                 // save user to DB
-                // await user.save();
+                await user.save();
 
                 // send email to user (will implement soon)
 

--- a/src/pages/api/auth/signup.js
+++ b/src/pages/api/auth/signup.js
@@ -18,17 +18,17 @@ export default async function handler(req, res) {
                     lastName,
                     email,
                     password,
-                    phoneNumber,
+                    // phoneNumber,
                     dateOfBirth,
-                    profilePicture,
-                    about,
+                    // profilePicture,
+                    // about,
                     location,
                 } = req.body;
 
                 // check if user already exists
                 let user = await User.findOne({ email });
                 if (user) {
-                    return res.status(400).json({ success: false, msg: "User already exists" });
+                    return res.status(400).json({ error: "User already exists" });
                 }
 
                 // hash password
@@ -41,15 +41,15 @@ export default async function handler(req, res) {
                     lastName,
                     email,
                     password: hashedPassword,
-                    phoneNumber,
+                    // phoneNumber,
                     dateOfBirth,
-                    profilePicture,
-                    about,
+                    // profilePicture,
+                    // about,
                     location,
                 });
 
                 // save user to DB
-                await user.save();
+                // await user.save();
 
                 // send email to user (will implement soon)
 
@@ -63,14 +63,19 @@ export default async function handler(req, res) {
                 // create jwt token
                 jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: "1h" }, (err, token) => {
                     if (err) throw err;
-                    res.status(200).json({ success: true, token });
+                    res.status(200).json({ token });
                 });
             } catch (error) {
-                res.status(400).json({ success: false });
+                // will have to change this error message in prod, since I'm taking the
+                // error message from this response and displaying it on the frontend
+                // or maybe we change how it works on the frontend idk but this is gonna
+                // have to be addressed eventually.
+                res.status(500).json({ error: `APIError: SignUp failed.\n${error}` });
             }
             break;
         default:
-            res.status(400).json({ success: false });
+            res.setHeader("Allow", ["POST"]);
+            res.status(405).json({ error: `Method ${req.method} Not Allowed` });
             break;
     }
 }

--- a/src/pages/api/auth/signup.js
+++ b/src/pages/api/auth/signup.js
@@ -1,0 +1,76 @@
+import bcrypt from "bcryptjs";
+import jwt from "jsonwebtoken";
+import User from "@/models/User";
+import connectMongo from "@/utils/connectMongo";
+
+// auth endpoint to sign up a user
+export default async function handler(req, res) {
+    // connect to DB
+    await connectMongo();
+
+    // switch statement for different request methods
+    switch (req.method) {
+        case "POST":
+            try {
+                // destructure req.body (just for convenience)
+                const {
+                    firstName,
+                    lastName,
+                    email,
+                    password,
+                    phoneNumber,
+                    dateOfBirth,
+                    profilePicture,
+                    about,
+                    location,
+                } = req.body;
+
+                // check if user already exists
+                let user = await User.findOne({ email });
+                if (user) {
+                    return res.status(400).json({ success: false, msg: "User already exists" });
+                }
+
+                // hash password
+                const salt = await bcrypt.genSalt(10);
+                const hashedPassword = await bcrypt.hash(password, salt);
+
+                // create new user object
+                user = new User({
+                    firstName,
+                    lastName,
+                    email,
+                    password: hashedPassword,
+                    phoneNumber,
+                    dateOfBirth,
+                    profilePicture,
+                    about,
+                    location,
+                });
+
+                // save user to DB
+                await user.save();
+
+                // send email to user (will implement soon)
+
+                // jwt payload
+                const payload = {
+                    user: {
+                        id: user.id,
+                    },
+                };
+
+                // create jwt token
+                jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: "1h" }, (err, token) => {
+                    if (err) throw err;
+                    res.status(200).json({ success: true, token });
+                });
+            } catch (error) {
+                res.status(400).json({ success: false });
+            }
+            break;
+        default:
+            res.status(400).json({ success: false });
+            break;
+    }
+}

--- a/src/pages/api/auth/signup.js
+++ b/src/pages/api/auth/signup.js
@@ -70,7 +70,7 @@ export default async function handler(req, res) {
                 // error message from this response and displaying it on the frontend
                 // or maybe we change how it works on the frontend idk but this is gonna
                 // have to be addressed eventually.
-                res.status(500).json({ error: `APIError: SignUp failed.\n${error}` });
+                res.status(500).json({ error: `APIError: Sign up failed.\n${error}` });
             }
             break;
         default:

--- a/src/pages/api/auth/signup.js
+++ b/src/pages/api/auth/signup.js
@@ -28,7 +28,7 @@ export default async function handler(req, res) {
                 // check if user already exists
                 let user = await User.findOne({ email });
                 if (user) {
-                    return res.status(400).json({ error: "User already exists" });
+                    return res.status(400).json({ error: "That email is already in use." });
                 }
 
                 // hash password

--- a/src/pages/api/listings/[listingId].js
+++ b/src/pages/api/listings/[listingId].js
@@ -8,7 +8,7 @@ export default async function handler(req, res) {
 
     // check if the listingId is a valid Mongo ObjectId
     if (!mongoose.Types.ObjectId.isValid(listingId)) {
-        return res.status(404).json({ message: "Listing ID not valid" });
+        return res.status(404).json({ error: "Listing ID not valid" });
     }
 
     try {
@@ -20,7 +20,7 @@ export default async function handler(req, res) {
 
         // if no listing found, return a 404
         if (!listing) {
-            return res.status(404).json({ message: "Listing not found" });
+            return res.status(404).json({ error: "Listing not found" });
         }
 
         // otherwise, return the found listing with 200 status code

--- a/src/pages/api/listings/index.js
+++ b/src/pages/api/listings/index.js
@@ -113,7 +113,7 @@ export default async function handler(req, res) {
 
                     res.status(200).json(availableListings);
                 } catch (error) {
-                    res.status(500).json({ message: "Internal Server Error" });
+                    res.status(500).json({ error: "Internal Server Error" });
                 }
             } else {
                 // query DB
@@ -121,7 +121,7 @@ export default async function handler(req, res) {
                     const listings = await Listing.find(dbQuery).exec();
                     res.status(200).json(listings);
                 } catch (error) {
-                    res.status(500).json({ message: "Internal Server Error" });
+                    res.status(500).json({ error: "Internal Server Error" });
                 }
             }
         } else {

--- a/src/pages/api/users/[userId].js
+++ b/src/pages/api/users/[userId].js
@@ -8,7 +8,7 @@ export default async function handler(req, res) {
 
     // check if the userId is a valid Mongo ObjectId
     if (!mongoose.Types.ObjectId.isValid(userId)) {
-        return res.status(404).json({ message: "User ID not valid" });
+        return res.status(404).json({ error: "User ID not valid" });
     }
 
     try {
@@ -20,7 +20,7 @@ export default async function handler(req, res) {
 
         // if no user found, return a 404
         if (!user) {
-            return res.status(404).json({ message: "User not found" });
+            return res.status(404).json({ error: "User not found" });
         }
 
         // otherwise, return the found user with 200 status code

--- a/src/pages/auth/signin.js
+++ b/src/pages/auth/signin.js
@@ -2,12 +2,9 @@ import React, { useState } from "react";
 import { useRouter } from "next/router";
 import { useAuth } from "@/hooks/useAuth";
 import BottomNav from "@/components/BottomNav";
-import { set } from "mongoose";
-import { cn } from "@/utils/utils";
 import Link from "next/link";
 import Input from "@/components/Input";
 import Button from "@/components/Button";
-import DatePicker from "@/components/DatePicker";
 import CircularProgress from "@mui/material/CircularProgress";
 import { jwtDecode } from "jwt-decode";
 

--- a/src/pages/auth/signin.js
+++ b/src/pages/auth/signin.js
@@ -7,6 +7,7 @@ import Input from "@/components/Input";
 import Button from "@/components/Button";
 import CircularProgress from "@mui/material/CircularProgress";
 import { jwtDecode } from "jwt-decode";
+import { IoClose } from "react-icons/io5";
 
 const SignIn = () => {
     const { saveUser } = useAuth();
@@ -47,7 +48,6 @@ const SignIn = () => {
                 // signin successful, save user in context and redirect to profile page
                 const data = await res.json();
                 const user = jwtDecode(data.token).user;
-                // alert("Sign in successful!");
                 saveUser(user);
                 router.push("/profile");
             }
@@ -68,8 +68,12 @@ const SignIn = () => {
 
                 {/* display error message if we have one */}
                 {apiError && (
-                    <div className="w-full rounded-md p-4 -mb-5 text-center text-base text-red-500">
+                    <div className="relative self-center w-4/5 rounded-sm px-4 py-4 text-center text-base bg-red-200 text-red-600">
                         <p>{apiError}</p>
+                        <IoClose
+                            onClick={() => setApiError(null)}
+                            className="absolute top-0 right-0 m-1 text-lg cursor-pointer text-slate-700"
+                        />
                     </div>
                 )}
 

--- a/src/pages/auth/signin.js
+++ b/src/pages/auth/signin.js
@@ -1,0 +1,116 @@
+import React, { useState } from "react";
+import { useRouter } from "next/router";
+import { useAuth } from "@/hooks/useAuth";
+import BottomNav from "@/components/BottomNav";
+import { set } from "mongoose";
+import { cn } from "@/utils/utils";
+import Link from "next/link";
+import Input from "@/components/Input";
+import Button from "@/components/Button";
+import DatePicker from "@/components/DatePicker";
+import CircularProgress from "@mui/material/CircularProgress";
+import { jwtDecode } from "jwt-decode";
+
+const SignIn = () => {
+    const { saveUser } = useAuth();
+    const router = useRouter();
+    const [formData, setFormData] = useState({
+        email: "",
+        password: "",
+    });
+    const [apiError, setApiError] = useState("");
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    // handle form input changes
+    const handleChange = (e) => {
+        setFormData({ ...formData, [e.target.name]: e.target.value });
+    };
+
+    // handle form submission
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+
+        // proceed with form submission
+        try {
+            setIsSubmitting(true);
+
+            // call signin API route
+            const res = await fetch("/api/auth/signin", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify(formData),
+            });
+            if (!res.ok) {
+                // signin failed, display error message
+                const error = JSON.parse(await res.text()).error;
+                setApiError(error);
+            } else {
+                // signin successful, save user in context and redirect to profile page
+                const data = await res.json();
+                const user = jwtDecode(data.token).user;
+                // alert("Sign in successful!");
+                saveUser(user);
+                router.push("/profile");
+            }
+
+            setIsSubmitting(false);
+        } catch (error) {
+            console.error("Signup failed", error);
+            setIsSubmitting(false);
+            throw new Error(`Signup failed, error not caught by API route:\n${error}`);
+        }
+    };
+
+    return (
+        <>
+            <div className="flex flex-col items-start justify-start min-h-screen gap-5 mx-8 pt-10 pb-32">
+                <h1 className="font-bold text-3xl">Sign In</h1>
+                <p className="text-lg text-slate-500">Lorem Ipsum.</p>
+
+                {/* display error message if we have one */}
+                {apiError && (
+                    <div className="w-full rounded-md p-4 -mb-5 text-center text-base text-red-500">
+                        <p>{apiError}</p>
+                    </div>
+                )}
+
+                {/* form */}
+                <form onSubmit={handleSubmit} className="flex flex-col gap-3 w-full">
+                    {/* email input */}
+                    <Input
+                        placeholder="Email"
+                        type="email"
+                        name="email"
+                        value={formData.email}
+                        onChange={handleChange}
+                    />
+
+                    {/* password input */}
+                    <Input
+                        placeholder="Password"
+                        type="password"
+                        name="password"
+                        value={formData.password}
+                        onChange={handleChange}
+                    />
+
+                    {/* submit button */}
+                    <Button type="submit">
+                        {isSubmitting ? <CircularProgress size={24} color="inherit" /> : "Sign In"}
+                    </Button>
+                </form>
+                <Link
+                    href="/auth/signup"
+                    className="self-end mr-2 underline cursor-pointer text-[#61C0BF]"
+                >
+                    Don't have an account? Sign Up.
+                </Link>
+            </div>
+            <BottomNav />
+        </>
+    );
+};
+
+export default SignIn;

--- a/src/pages/auth/signup.js
+++ b/src/pages/auth/signup.js
@@ -35,12 +35,20 @@ const validatePassword = (password) => {
 const SignupPage = () => {
     const { setUser } = useAuth();
     const [formData, setFormData] = useState({
+        firstName: "",
+        lastName: "",
+        dateOfBirth: new Date(),
+        location: "",
         email: "",
         password: "",
         confirmPassword: "",
     });
     const [errors, setErrors] = useState({});
     const [touched, setTouched] = useState({
+        firstName: false,
+        lastName: false,
+        dateOfBirth: false,
+        location: false,
         email: false,
         password: false,
         confirmPassword: false,
@@ -125,11 +133,38 @@ const SignupPage = () => {
                 <h1 className="font-bold text-3xl">Sign Up</h1>
                 <p className="text-lg text-slate-500">Lorem Ipsum.</p>
                 <form onSubmit={handleSubmit} className="flex flex-col gap-3 w-full">
+                    {/* first name input */}
+                    <AuthInput
+                        title="First Name"
+                        type="text"
+                        name="firstName"
+                        placeholder="John"
+                        value={formData.firstName}
+                        onChange={handleChange}
+                        onBlur={handleBlur}
+                        error={errors.firstName}
+                        touched={touched.firstName}
+                    />
+
+                    {/* last name input */}
+                    <AuthInput
+                        title="Last Name"
+                        type="text"
+                        name="lastName"
+                        placeholder="Doe"
+                        value={formData.lastName}
+                        onChange={handleChange}
+                        onBlur={handleBlur}
+                        error={errors.lastName}
+                        touched={touched.lastName}
+                    />
+
                     {/* email input */}
                     <AuthInput
+                        title="Email"
                         type="email"
                         name="email"
-                        placeholder="Email"
+                        placeholder="john@example.com"
                         value={formData.email}
                         onChange={handleChange}
                         onBlur={handleBlur}
@@ -139,9 +174,9 @@ const SignupPage = () => {
 
                     {/* password input */}
                     <AuthInput
+                        title="Password"
                         type="password"
                         name="password"
-                        placeholder="Password"
                         value={formData.password}
                         onChange={handleChange}
                         onBlur={handleBlur}
@@ -151,9 +186,9 @@ const SignupPage = () => {
 
                     {/* confirm password input */}
                     <AuthInput
+                        title="Confirm Password"
                         type="password"
                         name="confirmPassword"
-                        placeholder="Confirm Password"
                         value={formData.confirmPassword}
                         onChange={handleChange}
                         onBlur={handleBlur}

--- a/src/pages/auth/signup.js
+++ b/src/pages/auth/signup.js
@@ -1,0 +1,103 @@
+import React, { useState } from "react";
+import { useAuth } from "@/hooks/useAuth";
+import BottomNav from "@/components/BottomNav";
+
+const validateEmail = (email) => {
+    // simple regex for email validation
+    const re = /\S+@\S+\.\S+/;
+    return re.test(email) ? null : "Invalid email address";
+};
+
+const validatePassword = (password) => {
+    // check length
+    if (password.length < 8) {
+        return "Password must be at least 8 characters";
+    }
+
+    // // check for uppercase letter
+    // if (!/[A-Z]/.test(password)) {
+    //     return "Password must contain at least one uppercase letter";
+    // }
+
+    // more conditions here as needed, will discuss w Cem
+
+    // returning null if all conditions met (i.e. no error)
+    return null;
+};
+
+const SignupPage = () => {
+    const { setUser } = useAuth();
+    const [formData, setFormData] = useState({
+        email: "",
+        password: "",
+    });
+    const [errors, setErrors] = useState({});
+
+    // const handleChange = (e) => {
+    //     // Update formData
+    // };
+
+    // const handleSubmit = async (e) => {
+    //     e.preventDefault();
+    //     // Perform front-end validation
+    //     // POST request to backend
+    //     // On success, update AuthContext and redirect
+    //     // On failure, show error message
+    // };
+
+    const handleChange = (e) => {
+        setFormData({ ...formData, [e.target.name]: e.target.value });
+        // we could also validate inputs on change instead of submit
+        // think I might swap to this
+    };
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        const newErrors = {
+            email: validateEmail(formData.email),
+            password: validatePassword(formData.password),
+        };
+        setErrors(newErrors);
+
+        const isValid = Object.values(newErrors).every((error) => error === null);
+        if (isValid) {
+            // Proceed with form submission
+        }
+    };
+
+    return (
+        <>
+            <div className="flex flex-col items-start justify-start min-h-screen gap-5 mx-8 pt-10">
+                <h1 className="font-bold text-3xl">Sign Up</h1>
+                <p className="text-lg text-slate-500">Lorem Ipsum.</p>
+                <form onSubmit={handleSubmit}>
+                    <input
+                        type="email"
+                        name="email"
+                        value={formData.email}
+                        onChange={handleChange}
+                    />
+                    {errors.email && <p>{errors.email}</p>}
+
+                    <input
+                        type="password"
+                        name="password"
+                        value={formData.password}
+                        onChange={handleChange}
+                    />
+                    {errors.password && <p>{errors.password}</p>}
+
+                    <button
+                        type="submit"
+                        className="text-base inline-flex items-center justify-center h-11 px-8 py-2 rounded-md border bg-black text-white cursor-pointer"
+                    >
+                        Sign Up
+                    </button>
+                </form>
+            </div>
+            <BottomNav />
+        </>
+    );
+};
+
+export default SignupPage;

--- a/src/pages/auth/signup.js
+++ b/src/pages/auth/signup.js
@@ -6,6 +6,7 @@ import { cn } from "@/utils/utils";
 import Link from "next/link";
 import AuthInput from "@/components/AuthInput";
 import Button from "@/components/Button";
+import DatePicker from "@/components/DatePicker";
 
 // function to validate email
 const validateEmail = (email) => {
@@ -171,6 +172,9 @@ const SignupPage = () => {
                         error={errors.email}
                         touched={touched.email}
                     />
+
+                    {/* date of birth input */}
+                    <DatePicker />
 
                     {/* password input */}
                     <AuthInput

--- a/src/pages/auth/signup.js
+++ b/src/pages/auth/signup.js
@@ -1,20 +1,24 @@
 import React, { useState } from "react";
 import { useAuth } from "@/hooks/useAuth";
 import BottomNav from "@/components/BottomNav";
+import { set } from "mongoose";
+import { cn } from "@/utils/utils";
 
+// function to validate email
 const validateEmail = (email) => {
     // simple regex for email validation
     const re = /\S+@\S+\.\S+/;
     return re.test(email) ? null : "Invalid email address";
 };
 
+// function to validate password
 const validatePassword = (password) => {
     // check length
     if (password.length < 8) {
         return "Password must be at least 8 characters";
     }
 
-    // // check for uppercase letter
+    // // check for uppercase letter (commented out for now)
     // if (!/[A-Z]/.test(password)) {
     //     return "Password must contain at least one uppercase letter";
     // }
@@ -30,28 +34,24 @@ const SignupPage = () => {
     const [formData, setFormData] = useState({
         email: "",
         password: "",
+        confirmPassword: "",
     });
     const [errors, setErrors] = useState({});
+    const [touched, setTouched] = useState({
+        email: false,
+        password: false,
+        confirmPassword: false,
+    });
 
-    // const handleChange = (e) => {
-    //     // Update formData
-    // };
-
-    // const handleSubmit = async (e) => {
-    //     e.preventDefault();
-    //     // Perform front-end validation
-    //     // POST request to backend
-    //     // On success, update AuthContext and redirect
-    //     // On failure, show error message
-    // };
-
+    // handle form input changes
     const handleChange = (e) => {
         setFormData({ ...formData, [e.target.name]: e.target.value });
         // we could also validate inputs on change instead of submit
         // think I might swap to this
     };
 
-    const handleSubmit = (e) => {
+    // handle form submission
+    const handleSubmit = async (e) => {
         e.preventDefault();
         const newErrors = {
             email: validateEmail(formData.email),
@@ -61,7 +61,58 @@ const SignupPage = () => {
 
         const isValid = Object.values(newErrors).every((error) => error === null);
         if (isValid) {
-            // Proceed with form submission
+            // proceed with form submission
+            try {
+                // call signup API route
+                const res = await fetch("/api/auth/signup", {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify(formData),
+                });
+                if (!res.ok) {
+                    throw new Error("Signup failed. No 200 status code returned from API route.");
+                }
+
+                // response.ok is true, so grab response data
+                const data = await res.json();
+                if (data.success) {
+                    // update user context
+                    setUser(data.user);
+                } else {
+                    // handle errors here, will have to do this in UI and that will entail code here
+                    // just a console log for now
+                    console.error("API route returned success: false");
+                }
+            } catch (error) {
+                console.error("Signup failed", error);
+                throw new Error(`Signup failed, error not caught by API route:\n${error}`);
+            }
+        }
+    };
+
+    // function to validate when user leaves input field
+    const handleBlur = (e) => {
+        const { name } = e.target;
+        setTouched({ ...touched, [name]: true });
+        setErrors({ ...errors, [name]: validate(name, formData[name]) });
+    };
+
+    // function to choose appropriate validation function
+    const validate = (name, value) => {
+        switch (name) {
+            case "email":
+                return validateEmail(value);
+            case "password":
+                return validatePassword(value);
+            case "confirmPassword":
+                if (value !== formData.password) {
+                    return "Passwords do not match";
+                }
+                return null;
+            default:
+                return null;
         }
     };
 
@@ -70,23 +121,63 @@ const SignupPage = () => {
             <div className="flex flex-col items-start justify-start min-h-screen gap-5 mx-8 pt-10">
                 <h1 className="font-bold text-3xl">Sign Up</h1>
                 <p className="text-lg text-slate-500">Lorem Ipsum.</p>
-                <form onSubmit={handleSubmit}>
+                <form onSubmit={handleSubmit} className="flex flex-col gap-3 w-full">
+                    {/* email input */}
                     <input
                         type="email"
                         name="email"
+                        placeholder="Email"
                         value={formData.email}
                         onChange={handleChange}
+                        onBlur={handleBlur}
+                        className={cn(
+                            "border border-slate-300 rounded-md w-full h-11 px-4 py-2",
+                            touched.email && errors.email ? "border-red-500" : "border-slate-300"
+                        )}
                     />
-                    {errors.email && <p>{errors.email}</p>}
+                    {touched.email && errors.email && (
+                        <p className="text-sm ml-3 -mt-2 text-red-500">{errors.email}</p>
+                    )}
 
+                    {/* password input */}
                     <input
                         type="password"
                         name="password"
+                        placeholder="Password"
                         value={formData.password}
                         onChange={handleChange}
+                        onBlur={handleBlur}
+                        className={cn(
+                            "border border-slate-300 rounded-md w-full h-11 px-4 py-2",
+                            touched.password && errors.password
+                                ? "border-red-500"
+                                : "border-slate-300"
+                        )}
                     />
-                    {errors.password && <p>{errors.password}</p>}
+                    {touched.password && errors.password && (
+                        <p className="text-sm ml-3 -mt-2 text-red-500">{errors.password}</p>
+                    )}
 
+                    {/* confirm password input */}
+                    <input
+                        type="password"
+                        name="confirmPassword"
+                        placeholder="Confirm Password"
+                        value={formData.confirmPassword}
+                        onChange={handleChange}
+                        onBlur={handleBlur}
+                        className={cn(
+                            "border border-slate-300 rounded-md w-full h-11 px-4 py-2",
+                            touched.confirmPassword && errors.confirmPassword
+                                ? "border-red-500"
+                                : "border-slate-300"
+                        )}
+                    />
+                    {touched.confirmPassword && errors.confirmPassword && (
+                        <p className="text-sm ml-3 -mt-2 text-red-500">{errors.confirmPassword}</p>
+                    )}
+
+                    {/* submit button */}
                     <button
                         type="submit"
                         className="text-base inline-flex items-center justify-center h-11 px-8 py-2 rounded-md border bg-black text-white cursor-pointer"

--- a/src/pages/auth/signup.js
+++ b/src/pages/auth/signup.js
@@ -158,17 +158,12 @@ const SignUp = () => {
     // resetting the formData state for some reason.
     // workaround idea taken from: https://github.com/ErrorPro/react-google-autocomplete/issues/168
     const onPlaceSelectedRef = useRef(null);
-
     useEffect(() => {
         onPlaceSelectedRef.current = (place) => {
             // console.log("Place selected:", place);
             if (place && place.formatted_address) {
                 setFormData({ ...formData, location: place.formatted_address });
             } else {
-                // // Handle the case where place is undefined or doesn't have formatted_address
-                // console.error(
-                //     "Place selection failed or returned an undefined or unexpected result"
-                // );
                 return;
             }
         };
@@ -217,33 +212,17 @@ const SignUp = () => {
                     />
 
                     {/* location input */}
-                    {/* <AuthInput
-                        title="Location"
-                        type="text"
-                        name="location"
-                        placeholder="Toronto, ON, Canada"
-                        value={formData.location}
-                        onChange={handleChange}
-                        onBlur={handleBlur}
-                        error={errors.location}
-                        touched={touched.location}
-                    /> */}
                     <div className="flex flex-col">
                         <label className="text-base font-medium text-slate-900 mb-1 ml-0">
                             Location
                         </label>
                         <Autocomplete
                             apiKey={process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY}
-                            // onPlaceSelected={(place) => {
-                            //     console.log(formData);
-                            //     setFormData({ ...formData, location: place.formatted_address });
-                            // }}
                             onPlaceSelected={(place) => {
                                 if (onPlaceSelectedRef.current) {
                                     onPlaceSelectedRef.current(place);
                                 }
                             }}
-                            // defaultValue={formData.location}
                             className="border border-slate-300 rounded-md w-full h-11 px-4 py-2"
                             options={{
                                 types: ["(cities)"], // restrict search to cities only

--- a/src/pages/auth/signup.js
+++ b/src/pages/auth/signup.js
@@ -2,8 +2,6 @@ import React, { useState } from "react";
 import { useRouter } from "next/router";
 import { useAuth } from "@/hooks/useAuth";
 import BottomNav from "@/components/BottomNav";
-import { set } from "mongoose";
-import { cn } from "@/utils/utils";
 import Link from "next/link";
 import AuthInput from "@/components/AuthInput";
 import Button from "@/components/Button";

--- a/src/pages/auth/signup.js
+++ b/src/pages/auth/signup.js
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useRouter } from "next/router";
 import { useAuth } from "@/hooks/useAuth";
 import BottomNav from "@/components/BottomNav";
 import { set } from "mongoose";
@@ -46,7 +47,8 @@ const validateConfirmPassword = (confirmPassword, password) => {
 };
 
 const SignUp = () => {
-    const { setUser } = useAuth();
+    const { saveUser } = useAuth();
+    const router = useRouter();
     const [formData, setFormData] = useState({
         firstName: "",
         lastName: "",
@@ -99,15 +101,17 @@ const SignUp = () => {
                     body: JSON.stringify(formData),
                 });
                 if (!res.ok) {
+                    // signup failed, display error message
                     const error = JSON.parse(await res.text()).error;
                     setApiError(error);
-                    // throw new Error("Signup failed. No 200 status code returned from API route.");
                 } else {
+                    // signup successful, save user in context and redirect to profile page
                     const data = await res.json();
                     const user = jwtDecode(data.token).user;
                     console.log(user);
                     alert("Signup successful!");
-                    // setUser(user);
+                    saveUser(user);
+                    router.push("/profile");
                 }
 
                 setIsSubmitting(false);
@@ -116,7 +120,6 @@ const SignUp = () => {
                 setIsSubmitting(false);
                 throw new Error(`Signup failed, error not caught by API route:\n${error}`);
             }
-            // console.log(formData);
         }
     };
 
@@ -135,10 +138,6 @@ const SignUp = () => {
             case "password":
                 return validatePassword(value);
             case "confirmPassword":
-                // if (value !== formData.password) {
-                //     return "Passwords do not match";
-                // }
-                // return null;
                 return validateConfirmPassword(value, formData.password);
             default:
                 return null;

--- a/src/pages/auth/signup.js
+++ b/src/pages/auth/signup.js
@@ -4,6 +4,8 @@ import BottomNav from "@/components/BottomNav";
 import { set } from "mongoose";
 import { cn } from "@/utils/utils";
 import Link from "next/link";
+import AuthInput from "@/components/AuthInput";
+import Button from "@/components/Button";
 
 // function to validate email
 const validateEmail = (email) => {
@@ -51,6 +53,7 @@ const SignupPage = () => {
 
     // handle form submission
     const handleSubmit = async (e) => {
+        console.log("submit clicked");
         e.preventDefault();
         const newErrors = {
             email: validateEmail(formData.email),
@@ -60,34 +63,35 @@ const SignupPage = () => {
 
         const isValid = Object.values(newErrors).every((error) => error === null);
         if (isValid) {
-            // proceed with form submission
-            try {
-                // call signup API route
-                const res = await fetch("/api/auth/signup", {
-                    method: "POST",
-                    headers: {
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify(formData),
-                });
-                if (!res.ok) {
-                    throw new Error("Signup failed. No 200 status code returned from API route.");
-                }
+            // // proceed with form submission
+            // try {
+            //     // call signup API route
+            //     const res = await fetch("/api/auth/signup", {
+            //         method: "POST",
+            //         headers: {
+            //             "Content-Type": "application/json",
+            //         },
+            //         body: JSON.stringify(formData),
+            //     });
+            //     if (!res.ok) {
+            //         throw new Error("Signup failed. No 200 status code returned from API route.");
+            //     }
 
-                // response.ok is true, so grab response data
-                const data = await res.json();
-                if (data.success) {
-                    // update user context
-                    setUser(data.user);
-                } else {
-                    // handle errors here, will have to do this in UI and that will entail code here
-                    // just a console log for now
-                    console.error("API route returned success: false");
-                }
-            } catch (error) {
-                console.error("Signup failed", error);
-                throw new Error(`Signup failed, error not caught by API route:\n${error}`);
-            }
+            //     // response.ok is true, so grab response data
+            //     const data = await res.json();
+            //     if (data.success) {
+            //         // update user context
+            //         setUser(data.user);
+            //     } else {
+            //         // handle errors here, will have to do this in UI and that will entail code here
+            //         // just a console log for now
+            //         console.error("API route returned success: false");
+            //     }
+            // } catch (error) {
+            //     console.error("Signup failed", error);
+            //     throw new Error(`Signup failed, error not caught by API route:\n${error}`);
+            // }
+            console.log(formData);
         }
     };
 
@@ -122,71 +126,47 @@ const SignupPage = () => {
                 <p className="text-lg text-slate-500">Lorem Ipsum.</p>
                 <form onSubmit={handleSubmit} className="flex flex-col gap-3 w-full">
                     {/* email input */}
-                    <input
+                    <AuthInput
                         type="email"
                         name="email"
                         placeholder="Email"
                         value={formData.email}
                         onChange={handleChange}
                         onBlur={handleBlur}
-                        className={cn(
-                            "border border-slate-300 rounded-md w-full h-11 px-4 py-2",
-                            touched.email && errors.email ? "border-red-500" : "border-slate-300"
-                        )}
+                        error={errors.email}
+                        touched={touched.email}
                     />
-                    {touched.email && errors.email && (
-                        <p className="text-sm ml-3 -mt-2 text-red-500">{errors.email}</p>
-                    )}
 
                     {/* password input */}
-                    <input
+                    <AuthInput
                         type="password"
                         name="password"
                         placeholder="Password"
                         value={formData.password}
                         onChange={handleChange}
                         onBlur={handleBlur}
-                        className={cn(
-                            "border border-slate-300 rounded-md w-full h-11 px-4 py-2",
-                            touched.password && errors.password
-                                ? "border-red-500"
-                                : "border-slate-300"
-                        )}
+                        error={errors.password}
+                        touched={touched.password}
                     />
-                    {touched.password && errors.password && (
-                        <p className="text-sm ml-3 -mt-2 text-red-500">{errors.password}</p>
-                    )}
 
                     {/* confirm password input */}
-                    <input
+                    <AuthInput
                         type="password"
                         name="confirmPassword"
                         placeholder="Confirm Password"
                         value={formData.confirmPassword}
                         onChange={handleChange}
                         onBlur={handleBlur}
-                        className={cn(
-                            "border border-slate-300 rounded-md w-full h-11 px-4 py-2",
-                            touched.confirmPassword && errors.confirmPassword
-                                ? "border-red-500"
-                                : "border-slate-300"
-                        )}
+                        error={errors.confirmPassword}
+                        touched={touched.confirmPassword}
                     />
-                    {touched.confirmPassword && errors.confirmPassword && (
-                        <p className="text-sm ml-3 -mt-2 text-red-500">{errors.confirmPassword}</p>
-                    )}
 
                     {/* submit button */}
-                    <button
-                        type="submit"
-                        className="text-base inline-flex items-center justify-center h-11 px-8 py-2 rounded-md border bg-black text-white cursor-pointer"
-                    >
-                        Sign Up
-                    </button>
+                    <Button type="submit">Sign Up</Button>
                 </form>
                 <Link
                     href="/auth/signin"
-                    className="self-end mr-2 -mt-6 underline cursor-pointer text-[#61C0BF]"
+                    className="self-end mr-2 underline cursor-pointer text-[#61C0BF]"
                 >
                     Already have an account? Sign In.
                 </Link>

--- a/src/pages/auth/signup.js
+++ b/src/pages/auth/signup.js
@@ -3,6 +3,7 @@ import { useAuth } from "@/hooks/useAuth";
 import BottomNav from "@/components/BottomNav";
 import { set } from "mongoose";
 import { cn } from "@/utils/utils";
+import Link from "next/link";
 
 // function to validate email
 const validateEmail = (email) => {
@@ -46,8 +47,6 @@ const SignupPage = () => {
     // handle form input changes
     const handleChange = (e) => {
         setFormData({ ...formData, [e.target.name]: e.target.value });
-        // we could also validate inputs on change instead of submit
-        // think I might swap to this
     };
 
     // handle form submission
@@ -92,7 +91,7 @@ const SignupPage = () => {
         }
     };
 
-    // function to validate when user leaves input field
+    // function to validate when user leaves an input field
     const handleBlur = (e) => {
         const { name } = e.target;
         setTouched({ ...touched, [name]: true });
@@ -185,6 +184,12 @@ const SignupPage = () => {
                         Sign Up
                     </button>
                 </form>
+                <Link
+                    href="/auth/signin"
+                    className="self-end mr-2 -mt-6 underline cursor-pointer text-[#61C0BF]"
+                >
+                    Already have an account? Sign In.
+                </Link>
             </div>
             <BottomNav />
         </>

--- a/src/pages/auth/signup.js
+++ b/src/pages/auth/signup.js
@@ -8,6 +8,7 @@ import Button from "@/components/Button";
 import DatePicker from "@/components/DatePicker";
 import CircularProgress from "@mui/material/CircularProgress";
 import { jwtDecode } from "jwt-decode";
+import { useToast } from "@/components/ui/use-toast";
 
 // function to validate email
 const validateEmail = (email) => {
@@ -66,8 +67,8 @@ const SignUp = () => {
         password: false,
         confirmPassword: false,
     });
-    const [apiError, setApiError] = useState("");
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const { toast } = useToast();
 
     // handle form input changes
     const handleChange = (e) => {
@@ -101,22 +102,31 @@ const SignUp = () => {
                 if (!res.ok) {
                     // signup failed, display error message
                     const error = JSON.parse(await res.text()).error;
-                    setApiError(error);
+                    toast({
+                        variant: "destructive",
+                        title: "Uh oh, something went wrong.",
+                        description: error,
+                    });
                 } else {
                     // signup successful, save user in context and redirect to profile page
                     const data = await res.json();
                     const user = jwtDecode(data.token).user;
                     console.log(user);
-                    alert("Signup successful!");
+                    toast({
+                        variant: "success",
+                        title: "Sign up successful.",
+                        description: "Welcome!",
+                    });
                     saveUser(user);
                     router.push("/profile");
                 }
-
                 setIsSubmitting(false);
             } catch (error) {
                 console.error("Signup failed", error);
                 setIsSubmitting(false);
                 throw new Error(`Signup failed, error not caught by API route:\n${error}`);
+            } finally {
+                setIsSubmitting(false);
             }
         }
     };
@@ -147,13 +157,6 @@ const SignUp = () => {
             <div className="flex flex-col items-start justify-start min-h-screen gap-5 mx-8 pt-10 pb-32">
                 <h1 className="font-bold text-3xl">Sign Up</h1>
                 <p className="text-lg text-slate-500">Lorem Ipsum.</p>
-
-                {/* display error message if we have one */}
-                {apiError && (
-                    <div className="w-full rounded-md border border-red-500 p-4 text-center text-base text-red-500">
-                        <p>{apiError}</p>
-                    </div>
-                )}
 
                 {/* form */}
                 <form onSubmit={handleSubmit} className="flex flex-col gap-3 w-full">

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -55,15 +55,15 @@ export default function Explore() {
                 <Skeleton className="w-1/2 h-5" />
                 <Skeleton className="w-1/6 h-5 mb-6" />
                 {[...Array(3)].map((_, i) => (
-                    <>
-                        <Skeleton key={i} className="w-full h-52" />
-                        <Skeleton key={i} className="w-1/6 h-5" />
-                        <Skeleton key={i} className="w-1/2 h-5" />
+                    <div className="flex flex-col gap-3 w-full" key={i}>
+                        <Skeleton className="w-full h-52" />
+                        <Skeleton className="w-1/6 h-5" />
+                        <Skeleton className="w-1/2 h-5" />
                         <div className="flex justify-between w-full h-5 mb-7">
-                            <Skeleton key={i} className="w-1/3" />
-                            <Skeleton key={i} className="w-1/4" />
+                            <Skeleton className="w-1/3" />
+                            <Skeleton className="w-1/4" />
                         </div>
-                    </>
+                    </div>
                 ))}
             </div>
         );

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -76,10 +76,7 @@ export default function Explore() {
 
     return (
         <>
-            <main
-                // className={`flex min-h-screen flex-col items-center justify-between p-24 ${inter.className}`}
-                className="m-[2rem] min-h-screen flex flex-col gap-2"
-            >
+            <main className="m-[2rem] min-h-screen flex flex-col gap-2">
                 <h1 className="font-bold text-3xl">All listings</h1>
                 {currentUser ? <div>Welcome back {currentUser.firstName}</div> : null}
                 <p>{listings.length} listings</p>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -71,7 +71,12 @@ export default function Explore() {
 
     // show loading page until listings are successfully retrieved
     if (!listings.length) {
-        return <Loading />;
+        return (
+            <>
+                <Loading />
+                <BottomNav />
+            </>
+        );
     }
 
     return (

--- a/src/pages/profile.js
+++ b/src/pages/profile.js
@@ -3,8 +3,7 @@ import Link from "next/link";
 import { useAuth } from "@/hooks/useAuth";
 import Skeleton from "@/components/Skeleton";
 import BottomNav from "@/components/BottomNav";
-import { Button as ShadButton } from "@/components/ui/button";
-import Button from "@/components/Button";
+import { Button } from "@/components/ui/button";
 
 const profile = () => {
     // get user object from context
@@ -70,21 +69,14 @@ const profile = () => {
                 <div className="flex flex-col items-start justify-start min-h-screen gap-5 mx-8 pt-10">
                     <h1>Welcome, {user?.firstName}!</h1>
                     <p>Email: {user?.email}</p>
-                    <ShadButton
+                    <Button
                         variant="outline"
                         size="lg"
                         className="font-normal text-base text-slate-600"
-                        // onClick={() => alert("log out")}
                         onClick={signOut}
                     >
                         Sign Out
-                    </ShadButton>
-                    {/* <Button
-                        className="border border-slate-300 bg-white text-slate-500"
-                        onClick={() => alert("log out")}
-                    >
-                        Log out
-                    </Button> */}
+                    </Button>
                 </div>
             ) : (
                 <div className="flex flex-col items-start justify-start min-h-screen gap-5 mx-8 pt-10">

--- a/src/pages/profile.js
+++ b/src/pages/profile.js
@@ -4,6 +4,8 @@ import { useAuth } from "@/hooks/useAuth";
 import Skeleton from "@/components/Skeleton";
 import BottomNav from "@/components/BottomNav";
 import { Button } from "@/components/ui/button";
+import ProfileImagePlaceholder from "@/components/ProfileImagePlaceholder";
+import { cn } from "@/utils/utils";
 
 const profile = () => {
     // get user object from context
@@ -31,11 +33,12 @@ const profile = () => {
                 if (!response.ok) {
                     const error = await response.json().error;
                     setError(`Error ${response.status}: ${error}`);
-                    setLoadingUserDetails(false);
+                    setLoadingUserInfo(false);
                     return;
                 }
                 const data = await response.json();
                 setUser(data);
+                // console.log(data);
             } catch (error) {
                 setError(error.message ? error.message : error);
             } finally {
@@ -92,8 +95,51 @@ const profile = () => {
                         </div>
                     )}
 
-                    <h1>Welcome, {user?.firstName}!</h1>
-                    <p>Email: {user?.email}</p>
+                    {/* display profile img and welcome message/email */}
+                    {/* (subject to change, just placeholders for now) */}
+                    <div className="flex items-center gap-6">
+                        {user?.profileImage ? (
+                            <img src={user.profileImage} className="h-20 w-20 rounded-full" />
+                        ) : (
+                            <ProfileImagePlaceholder />
+                        )}
+                        <div className="flex flex-col gap-3 items-start justify-center">
+                            <h1>Welcome, {user?.firstName}!</h1>
+                            <p>Email: {user?.email}</p>
+                        </div>
+                    </div>
+
+                    {/* content */}
+                    <div className="w-full flex flex-col gap-1">
+                        {/* account links */}
+                        <div className="flex flex-col border-y border-slate-200 py-2">
+                            <h2 className="text-2xl font-bold mb-1">Account</h2>
+                            <div className="flex flex-col">
+                                {/* will prob replace these divs with Links later */}
+                                <div className="text-base hover:bg-slate-100 hover:rounded-sm py-2 px-2 transition-all">
+                                    Personal Info
+                                </div>
+                                <div className="text-base hover:bg-slate-100 hover:rounded-sm py-2 px-2 transition-all">
+                                    Account Settings
+                                </div>
+                            </div>
+                        </div>
+                        {/* tenant links */}
+                        <div className="flex flex-col border-b border-slate-200 py-2">
+                            <h2 className="text-2xl font-bold mb-1">Tenant</h2>
+                            <div className="flex flex-col">
+                                {/* will prob replace these divs with Links later */}
+                                <div className="text-base hover:bg-slate-100 hover:rounded-sm py-2 px-2 transition-all">
+                                    List a sublet
+                                </div>
+                                <div className="text-base hover:bg-slate-100 hover:rounded-sm py-2 px-2 transition-all">
+                                    Switch to hosting
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    {/* sign out button */}
                     <Button
                         variant="outline"
                         size="lg"

--- a/src/pages/profile.js
+++ b/src/pages/profile.js
@@ -1,12 +1,37 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import Link from "next/link";
 import { useAuth } from "@/hooks/useAuth";
 import Skeleton from "@/components/Skeleton";
 import BottomNav from "@/components/BottomNav";
+import { Button as ShadButton } from "@/components/ui/button";
+import Button from "@/components/Button";
 
 const profile = () => {
     // get user object from context
-    const { user, loading } = useAuth();
+    // will ONLY contain ID. this is for security reasons
+    // we will use this ID to fetch the rest of their info from the db
+    const { user: contextUser, loading, signOut } = useAuth();
+    console.log(contextUser);
+
+    // state for user object that will be fetched from db
+    const [user, setUser] = useState(null);
+
+    // fetch user data if user is logged in (i.e. contextUser is not null)
+    useEffect(() => {
+        // do nothing if user is not logged in
+        if (!contextUser) return;
+
+        // fetch user
+        const fetchUser = async () => {
+            const response = await fetch(`/api/users/${contextUser?.id}`);
+            if (!response.ok) {
+                throw new Error("Failed to fetch user :(");
+            }
+            const data = await response.json();
+            setUser(data);
+        };
+        fetchUser();
+    }, [contextUser]);
 
     // loading component
     const Loading = () => {
@@ -41,11 +66,25 @@ const profile = () => {
 
     return (
         <>
-            {user ? (
-                <div>
-                    <h1>Welcome, {user.firstName}!</h1>
-                    <p>Email: {user.email}</p>
-                    {/* gonna add more user info here and style properly */}
+            {contextUser ? (
+                <div className="flex flex-col items-start justify-start min-h-screen gap-5 mx-8 pt-10">
+                    <h1>Welcome, {user?.firstName}!</h1>
+                    <p>Email: {user?.email}</p>
+                    <ShadButton
+                        variant="outline"
+                        size="lg"
+                        className="font-normal text-base text-slate-600"
+                        // onClick={() => alert("log out")}
+                        onClick={signOut}
+                    >
+                        Sign Out
+                    </ShadButton>
+                    {/* <Button
+                        className="border border-slate-300 bg-white text-slate-500"
+                        onClick={() => alert("log out")}
+                    >
+                        Log out
+                    </Button> */}
                 </div>
             ) : (
                 <div className="flex flex-col items-start justify-start min-h-screen gap-5 mx-8 pt-10">

--- a/src/pages/profile.js
+++ b/src/pages/profile.js
@@ -1,0 +1,77 @@
+import React from "react";
+import Link from "next/link";
+import { useAuth } from "@/hooks/useAuth";
+import Skeleton from "@/components/Skeleton";
+import BottomNav from "@/components/BottomNav";
+
+const profile = () => {
+    // get user object from context
+    const { user, loading } = useAuth();
+
+    // loading component
+    const Loading = () => {
+        return (
+            <div className="flex flex-col items-start justify-start min-h-screen gap-5 mx-8 pt-10">
+                <div className="flex items-center gap-5">
+                    <Skeleton className="h-20 w-20 rounded-full" />
+                    <div className="flex flex-col gap-2">
+                        <Skeleton className="h-6 w-36" />
+                        <Skeleton className="h-5 w-52" />
+                    </div>
+                </div>
+                <div className="h-[1px] bg-slate-200 w-full" />
+                {[...Array(3)].map((_, i) => (
+                    <>
+                        <div className="flex flex-col gap-3 w-full">
+                            <Skeleton className="w-1/3 h-6 mb-1" />
+                            <Skeleton className="w-1/4 h-5" />
+                            <Skeleton className="w-1/2 h-5" />
+                            <Skeleton className="w-1/3 h-5" />
+                        </div>
+                        <div className="h-[1px] bg-slate-200 w-full" />
+                    </>
+                ))}
+            </div>
+        );
+    };
+
+    if (loading) {
+        return <Loading />;
+    }
+
+    return (
+        <>
+            {user ? (
+                <div>
+                    <h1>Welcome, {user.firstName}!</h1>
+                    <p>Email: {user.email}</p>
+                    {/* gonna add more user info here and style properly */}
+                </div>
+            ) : (
+                <div className="flex flex-col items-start justify-start min-h-screen gap-5 mx-8 pt-10">
+                    <h1 className="font-bold text-3xl">Guest</h1>
+                    <p className="text-lg text-slate-500">
+                        You are not logged in. Please sign in or sign up to view your profile.
+                    </p>
+                    <div className="flex items-center gap-5">
+                        <Link
+                            className="text-base inline-flex items-center justify-center h-11 px-8 py-2 rounded-md border border-slate-500 text-slate-500 cursor-pointer"
+                            href="/auth/signin"
+                        >
+                            Sign In
+                        </Link>
+                        <Link
+                            className="text-base inline-flex items-center justify-center h-11 px-8 py-2 rounded-md border bg-black text-white cursor-pointer"
+                            href="/auth/signup"
+                        >
+                            Sign Up
+                        </Link>
+                    </div>
+                </div>
+            )}
+            <BottomNav />
+        </>
+    );
+};
+
+export default profile;

--- a/src/pages/profile.js
+++ b/src/pages/profile.js
@@ -6,6 +6,10 @@ import BottomNav from "@/components/BottomNav";
 import { Button } from "@/components/ui/button";
 import ProfileImagePlaceholder from "@/components/ProfileImagePlaceholder";
 import { cn } from "@/utils/utils";
+import { FaRegUser } from "react-icons/fa6";
+import { IoSettingsOutline } from "react-icons/io5";
+import { PiHouse } from "react-icons/pi";
+import { GoArrowSwitch } from "react-icons/go";
 
 const profile = () => {
     // get user object from context
@@ -116,10 +120,22 @@ const profile = () => {
                             <h2 className="text-2xl font-bold mb-1">Account</h2>
                             <div className="flex flex-col">
                                 {/* will prob replace these divs with Links later */}
-                                <div className="text-base hover:bg-slate-100 hover:rounded-sm py-2 px-2 transition-all">
+                                <div
+                                    className={cn(
+                                        "text-base hover:bg-slate-100 hover:rounded-sm py-2 px-2 transition-all",
+                                        "flex items-center gap-2"
+                                    )}
+                                >
+                                    <FaRegUser className="text-lg" />
                                     Personal Info
                                 </div>
-                                <div className="text-base hover:bg-slate-100 hover:rounded-sm py-2 px-2 transition-all">
+                                <div
+                                    className={cn(
+                                        "text-base hover:bg-slate-100 hover:rounded-sm py-2 px-2 transition-all",
+                                        "flex items-center gap-2"
+                                    )}
+                                >
+                                    <IoSettingsOutline className="text-lg" />
                                     Account Settings
                                 </div>
                             </div>
@@ -129,10 +145,22 @@ const profile = () => {
                             <h2 className="text-2xl font-bold mb-1">Tenant</h2>
                             <div className="flex flex-col">
                                 {/* will prob replace these divs with Links later */}
-                                <div className="text-base hover:bg-slate-100 hover:rounded-sm py-2 px-2 transition-all">
+                                <div
+                                    className={cn(
+                                        "text-base hover:bg-slate-100 hover:rounded-sm py-2 px-2 transition-all",
+                                        "flex items-center gap-2"
+                                    )}
+                                >
+                                    <PiHouse className="text-lg" />
                                     List a sublet
                                 </div>
-                                <div className="text-base hover:bg-slate-100 hover:rounded-sm py-2 px-2 transition-all">
+                                <div
+                                    className={cn(
+                                        "text-base hover:bg-slate-100 hover:rounded-sm py-2 px-2 transition-all",
+                                        "flex items-center gap-2"
+                                    )}
+                                >
+                                    <GoArrowSwitch className="text-lg" />
                                     Switch to hosting
                                 </div>
                             </div>

--- a/src/pages/profile.js
+++ b/src/pages/profile.js
@@ -21,7 +21,7 @@ const profile = () => {
                 </div>
                 <div className="h-[1px] bg-slate-200 w-full" />
                 {[...Array(3)].map((_, i) => (
-                    <>
+                    <div className="flex flex-col gap-5 w-full" key={i}>
                         <div className="flex flex-col gap-3 w-full">
                             <Skeleton className="w-1/3 h-6 mb-1" />
                             <Skeleton className="w-1/4 h-5" />
@@ -29,7 +29,7 @@ const profile = () => {
                             <Skeleton className="w-1/3 h-5" />
                         </div>
                         <div className="h-[1px] bg-slate-200 w-full" />
-                    </>
+                    </div>
                 ))}
             </div>
         );

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,24 +1,76 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+ 
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 222.2 84% 4.9%;
 
-:root {
-    --foreground-rgb: 0, 0, 0;
-    --background-start-rgb: 214, 219, 220;
-    --background-end-rgb: 255, 255, 255;
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 84% 4.9%;
+ 
+    --popover: 0 0% 100%;
+    --popover-foreground: 222.2 84% 4.9%;
+ 
+    --primary: 222.2 47.4% 11.2%;
+    --primary-foreground: 210 40% 98%;
+ 
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+ 
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+ 
+    --accent: 210 40% 96.1%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+ 
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --ring: 222.2 84% 4.9%;
+ 
+    --radius: 0.5rem;
+  }
+ 
+  .dark {
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+ 
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+ 
+    --popover: 222.2 84% 4.9%;
+    --popover-foreground: 210 40% 98%;
+ 
+    --primary: 210 40% 98%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+ 
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+ 
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+ 
+    --accent: 217.2 32.6% 17.5%;
+    --accent-foreground: 210 40% 98%;
+ 
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+ 
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 212.7 26.8% 83.9%;
+  }
 }
-
-@media (prefers-color-scheme: dark) {
-    :root {
-        --foreground-rgb: 255, 255, 255;
-        --background-start-rgb: 0, 0, 0;
-        --background-end-rgb: 0, 0, 0;
-    }
-}
-
-body {
-    color: rgb(var(--foreground-rgb));
-    /* background: linear-gradient(to bottom, transparent, rgb(var(--background-end-rgb)))
-        rgb(var(--background-start-rgb)); */
-    background: white;
+ 
+@layer base {
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
 }

--- a/src/utils/connectMongo.js
+++ b/src/utils/connectMongo.js
@@ -3,7 +3,7 @@ import mongoose from "mongoose";
 // function to connect to the MongoDB client
 async function connectMongo() {
     try {
-        // Connect the client to the server
+        // connect the client to the server
         const { connection } = await mongoose.connect(process.env.MONGO_URI);
 
         // check ready state and return promise

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,18 +1,76 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+    darkMode: ["class"],
     content: [
         "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
         "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
         "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+        "./src/**/*.{js,ts,jsx,tsx,mdx}",
     ],
     theme: {
+        container: {
+            center: true,
+            padding: "2rem",
+            screens: {
+                "2xl": "1400px",
+            },
+        },
         extend: {
-            backgroundImage: {
-                "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
-                "gradient-conic":
-                    "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
+            colors: {
+                border: "hsl(var(--border))",
+                input: "hsl(var(--input))",
+                ring: "hsl(var(--ring))",
+                background: "hsl(var(--background))",
+                foreground: "hsl(var(--foreground))",
+                primary: {
+                    DEFAULT: "hsl(var(--primary))",
+                    foreground: "hsl(var(--primary-foreground))",
+                },
+                secondary: {
+                    DEFAULT: "hsl(var(--secondary))",
+                    foreground: "hsl(var(--secondary-foreground))",
+                },
+                destructive: {
+                    DEFAULT: "hsl(var(--destructive))",
+                    foreground: "hsl(var(--destructive-foreground))",
+                },
+                muted: {
+                    DEFAULT: "hsl(var(--muted))",
+                    foreground: "hsl(var(--muted-foreground))",
+                },
+                accent: {
+                    DEFAULT: "hsl(var(--accent))",
+                    foreground: "hsl(var(--accent-foreground))",
+                },
+                popover: {
+                    DEFAULT: "hsl(var(--popover))",
+                    foreground: "hsl(var(--popover-foreground))",
+                },
+                card: {
+                    DEFAULT: "hsl(var(--card))",
+                    foreground: "hsl(var(--card-foreground))",
+                },
+            },
+            borderRadius: {
+                lg: "var(--radius)",
+                md: "calc(var(--radius) - 2px)",
+                sm: "calc(var(--radius) - 4px)",
+            },
+            keyframes: {
+                "accordion-down": {
+                    from: { height: 0 },
+                    to: { height: "var(--radix-accordion-content-height)" },
+                },
+                "accordion-up": {
+                    from: { height: "var(--radix-accordion-content-height)" },
+                    to: { height: 0 },
+                },
+            },
+            animation: {
+                "accordion-down": "accordion-down 0.2s ease-out",
+                "accordion-up": "accordion-up 0.2s ease-out",
             },
         },
     },
-    plugins: [],
+    plugins: [require("tailwindcss-animate")],
 };


### PR DESCRIPTION
closes #3

Did the following things in this PR:

## Auth Context
- Added `AuthContext` which stores user object in context and in local storage
  - Provides a `saveUser` function to save a new user to context (when signing in or signing up)
  - Provides a `signOut` function which deletes user object from context and local storage
  - Provides a `loading` prop so pages can render a loading component until user object is fetched from context
  - N.B. The user object only contains user ID. Pages will use the ID to call `/api/users/[userId]` to get the rest of the user info. This is for security to make sure sensitive user info isn't passed in the JWT
- Added `useAuth` hook to access `AuthContext`


## API Routes
- Added `/api/auth/signup` route:
  - Accepts a `POST` request with a body containing the user's information (first name, last name, location, date of birth, email, password)
  - Checks if a user with that email exists already, if they do returns a 400 error letting the UI know this
  - Otherwise, creates the new user object (hashing the password), saves it to DB, and returns a JWT containing the user ID
- Added `/api/auth/signin` route:
  - Accepts a `POST` request with a body containing the user's email and password
  - If user with that email does not exist OR the password is incorrect, returns a 400 error with the same error message
  - If user with email exists and the password comparison passes, signs in the user and returns a JWT containing the user ID


## Components

### Shadcn UI
- Added [shadcn-ui](https://ui.shadcn.com/) to the project, just a component library
- This added a bunch of CSS variables to the `globals.css` and `tailwind.config.js` files but we can go through and streamline those with any other ones we create later on
- It also added a bunch of other config stuff to the `tailwind.config.js` file. Haven't dived into what it all does yet but the components are working so not gonna touch it until we need to I think
- Added their `button`, `calendar`, `popover`, `select`, `toast`, and `toaster` components which were all either used to create the custom components below or were used directly in one of the new pages
- All the shadcn-ui components are in the `/src/components/ui/` folder

### Custom Components
- `Input.js`
  - Just a wrapper around an `<input>` tag to add some base styling
  - Propagates all the props to the inner `<input>`
  - Concatenates the `className` prop using the `cn` util function which just merges Tailwind classes, will add any extra Tailwind styles to the base styles on the component
- `Button.js`
  - Pretty much exactly the same as the `Input` component but wrapping a `<button>` tag instead
- `AuthInput.js`
  - A wrapper arount the `Input` component lol
  - Basically just adds a label, an optional error message, and a red border if there's an error
- `ProfileImagePlaceholder.js`
  - Self explanatory ahah
  - Currently is a fixed width/height, in future will probably make that variable and passed as a prop
- `DatePicker.js`
  - Built using the `button`, `calendar`, `popover`, and `select` components from shadcn-ui
  - Has a year picker and a month picker to make bday selection easier (instead of having to scroll through like 12*ur age number of months to get to it lmao)


## Pages
- Added `Profile` page:
  - If user is not logged in, will show a "Guest" page with links to sign in or sign up
  - If user is logged in, will show the profile page with their information
  - Also uses `Skeleton` components for the loading screen
- Added `SignUp` page:
  - Has fields for date of birth (using `DatePicker`), first name, last name, location (autocomplete with Google Maps API), email, password and confirm password
  - Uses shadcn-ui `toast` component to display API error messages or a "sign up successful" message
  - If sign up is successful, auto-navigates user back to the profile page where they will now be logged in
  - Has a link over to `SignIn` page
  - Also, the "Sign Up" button will display a circular progress icon while submission is occurring
- Added `SignIn` page:
  - Has fields for email and password
  - If there is a sign in error, it will be displayed right above the fields as an error box with a red background (instead of a toast, did a bunch of research into like existing sign in and sign up pages and it seems like the most common is for toasts to be used on sign up and then just regular error boxes on sign in)
  - Has a link over to `SignUp` page
  - "Sign In' button also displays circular progress icon while submission is occurring


## Miscellaneous
- Added the `cn()` function to `/src/utils/utils.js`. As mentioned above this function just merges Tailwind classes. Helps with handling custom components
- Slightly changed the existing functionality in the `/src/components/ui/use-toast.js` hook from shadcn-ui. Their toast delay logic wasn't working so I fixed it lol
- Also set the toast delay to 2 seconds for now. Did some experimentaiton with it and 2 seconds felt the most natural